### PR TITLE
Convert to <v-data-table-server> component for rendering data, custom pagination, and disable search feature

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -504,9 +504,7 @@ function loadItems() {
         watchers: item.watchers
       }
     })
-    // TODO: assign below to response.data.last_page once API provides it
-    lastPage.value = false
-
+    lastPage.value = response.data.last_page
     totalItems.value = response.data.data.length
     loading.value = false
   })

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -489,7 +489,12 @@ onMounted(() => {
 // function loadItems({ page }) {
 function loadItems() {
   loading.value = true
-  axios.get(`${runtimeConfig.public.API_URL}/tasks/?page=` + (page.value - 1))
+  let axiosGetRequestURL = `${runtimeConfig.public.API_URL}/tasks/?page=` + (page.value - 1)
+
+  // set filters
+  if(filterByUser.value) axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + clickUpUserInfo.value.id
+
+  axios.get(axiosGetRequestURL)
   .then((response) => {
     // data.value = response.data.data.slice(0, 10).map((item) => {
     data.value = response.data.data.map((item) => {
@@ -702,6 +707,8 @@ function filterByUserToggle (type) {
   } else {
     filterByUser.value = false
   } 
+
+  loadItems()
 }
 
 // priority color method for v-chip component

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -218,12 +218,13 @@
 
       <template v-slot:bottom v-if="!showFooter"></template>
     </v-data-table-server>
-
-    <v-pagination 
-      v-model="page" 
-      :length="paginationLength"
-    >
-    </v-pagination>
+  </v-container>
+  
+  <v-container>
+    <v-row justify="center" align="center">
+      <v-btn class="rounded-0" flat :disabled="previousPageBtnDisabled" @click="decrementPage">Previous page</v-btn>
+      <v-btn class="rounded-0" flat :disabled="nextPageBtnDisabled" @click="incrementPage">Next page</v-btn>
+    </v-row>
   </v-container>
   <!-- </div> -->
 </template>
@@ -247,8 +248,8 @@ const itemsPerPage = ref(100)
 const loading = ref(true)
 const totalItems = ref(0)
 const showFooter = ref(false)
-const page = ref(1)
-const paginationLength = ref(8) // TODO: need to figure out how to retrieve length prop dynamically
+const page = ref(0)
+const lastPage = ref(false)
 //
 
 
@@ -366,6 +367,16 @@ const formTitle = computed(() => {
   return editedIndex.value === -1 ? 'New Work Order Form' : 'Edit Work Order Form'
 })
 
+// computed value to disable / enable the "Previous page" button
+const previousPageBtnDisabled = computed(() => {
+  return (page.value === 0) ? true : false
+})
+
+// computed value to disable / enable the "Next page" button
+const nextPageBtnDisabled = computed(() => {
+  return (lastPage.value) ? true : false
+})
+
 // computed value for work order submit progress messages
 const onSubmitMsg = computed(() => {
   switch(submitStatus.value) {
@@ -464,7 +475,7 @@ onMounted(() => {
 // function loadItems({ page }) {
 function loadItems() {
   loading.value = true
-  let axiosGetRequestURL = `${runtimeConfig.public.API_URL}/tasks/?page=` + (page.value - 1)
+  let axiosGetRequestURL = `${runtimeConfig.public.API_URL}/tasks/?page=` + page.value
 
   // set filters
   if(filterByUser.value) axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + clickUpUserInfo.value.id
@@ -492,6 +503,9 @@ function loadItems() {
         watchers: item.watchers
       }
     })
+    // TODO: assign below to response.data.last_page once API provides it
+    lastPage.value = false
+
     totalItems.value = response.data.data.length
     loading.value = false
   })
@@ -564,7 +578,6 @@ function loadLists(presentFolderId) {
   })
   .catch(err => console.log(err))
 }
-
 
 function editItem(item) {
   editedIndex.value = data.value.indexOf(item)
@@ -684,6 +697,14 @@ function filterByUserToggle (type) {
   } 
 
   loadItems()
+}
+
+function incrementPage() {
+  page.value = (page.value + 1)
+}
+
+function decrementPage() {
+  page.value = (page.value - 1)
 }
 
 // priority color method for v-chip component

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -239,21 +239,14 @@ import { convertToDate, dateToISOStr, hoursToMilliseconds } from '~/helpers/date
 import { capitalizeFirstLetter } from '~/helpers/capitalizeFirstLetter.js';
 
 const runtimeConfig = useRuntimeConfig()
-    
 const authStore = useAuthStore()
 const dialog = ref(false)
-
-
-// server table data
 const itemsPerPage = ref(100)
 const loading = ref(true)
 const totalItems = ref(0)
 const showFooter = ref(false)
 const page = ref(0)
 const lastPage = ref(false)
-//
-
-
 const editedIndex = ref(-1)
 const data = ref([])
 const search = ref('')
@@ -262,16 +255,11 @@ const drawer = ref(false)
 const form = ref(null)
 const tags = ref([])
 const members = ref([])
-
 const folders = ref([])
 const lists = ref([])
-
 const formTab = ref(null)
-
 const clickUpUserInfo = ref()
-
 const submitBtnDisabled = ref(false)
-
 const submitStatusOverlay = ref(false)
 const submitStatus = ref('')
 const submitErrorInfo = ref('')
@@ -732,8 +720,7 @@ function getDueDateColor(rawDateTime, status) {
   const todayPlusFiveDays = Number(todayInMS) + 432000000
 
   // if task is not complete, then set color
-  // red for overdue, or due today
-  // yellow for due within 5 days
+  // red for overdue (or due today), yellow for due within 5 days
   if(status != "complete") {
     if (todayInMS >= date) {
       color = "#f50000"

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -369,12 +369,12 @@ const formTitle = computed(() => {
 
 // computed value to disable / enable the "Previous page" button
 const previousPageBtnDisabled = computed(() => {
-  return (page.value === 0) ? true : false
+  return (loading.value) ? true : (page.value === 0) ? true : false
 })
 
 // computed value to disable / enable the "Next page" button
 const nextPageBtnDisabled = computed(() => {
-  return (lastPage.value) ? true : false
+  return (loading.value) ? true : (lastPage.value) ? true : false
 })
 
 // computed value for work order submit progress messages

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -47,15 +47,6 @@
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
       @update:options="loadItems"
     >
-    <!-- <v-data-table
-      :headers="headers" 
-      :items="filteredData" 
-      :group-by="groupBy"
-      :loading="loading" 
-      class="elevation-1"
-      :search="search"
-      @click:row="(pointerEvent, {item}) => editItem(item.raw)"
-    > -->
       <template v-slot:top>
         <!-- <v-toolbar flat> -->
 
@@ -389,22 +380,6 @@ const onSubmitMsg = computed(() => {
     default:
       return ''
   }
-})
-
-// computed value for filtering data by logged-in user 
-// checks work order's assignee's email address against logged-in user's AD email
-const filteredData = computed(() => {
-  if(filterByUser.value){
-    let output = data.value.filter(item => {
-      if(item.assignees) {
-        let opt = item.assignees.some((
-          { email }) => email == authStore.currentUser.username)
-        return opt
-      }
-    })
-    return output
-  }
-  return data.value
 })
 
 // computed value for toggling group-by behavior

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -20,19 +20,20 @@
     <AuthN></AuthN>
   </v-app-bar>
 
-  <v-text-field
-    v-model="search"
-    append-icon="mdi-magnify"
-    label="Search"
-    single-line
-    density="comfortable"
-    hide-details
-  ></v-text-field>
+  <v-container v-if="clickUpUserInfo" fluid>
+    <v-text-field
+      v-model="search"
+      append-icon="mdi-magnify"
+      label="Search"
+      single-line
+      density="comfortable"
+      hide-details
+    ></v-text-field>
 
-  <!-- <div v-if="!clickUpUserInfo.length">
-    <p>Please register for a KAI ClickUp account to use this application</p>
-  </div> -->
-  <!-- <div v-else>  -->
+    <!-- <div v-if="!clickUpUserInfo.length">
+      <p>Please register for a KAI ClickUp account to use this application</p>
+    </div> -->
+    <!-- <div v-else>  -->
     <v-data-table-server
       v-model:page="page"
       :headers="headers" 
@@ -45,7 +46,6 @@
       :search="search"
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
       @update:options="loadItems"
-      v-if="clickUpUserInfo"
     >
     <!-- <v-data-table
       :headers="headers" 
@@ -232,7 +232,8 @@
       v-model="page" 
       :length="paginationLength"
     >
-  </v-pagination>
+    </v-pagination>
+  </v-container>
   <!-- </div> -->
 </template>
 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -24,10 +24,11 @@
     <v-text-field
       v-model="search"
       append-icon="mdi-magnify"
-      label="Search"
+      label="Search (TBD)"
       single-line
       density="comfortable"
       hide-details
+      disabled
     ></v-text-field>
 
     <!-- <div v-if="!clickUpUserInfo.length">

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -36,7 +36,6 @@
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
       @update:options="loadItems"
     >
-    <template #bottom v-if="!showFooter"></template>
     <!-- <v-data-table
       :headers="headers" 
       :items="filteredData" 
@@ -225,6 +224,7 @@
         </v-icon> -->
       </template>
 
+      <template v-slot:bottom v-if="!showFooter"></template>
     </v-data-table-server>
 
     <v-pagination 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -45,6 +45,7 @@
       :search="search"
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
       @update:options="loadItems"
+      v-if="clickUpUserInfo"
     >
     <!-- <v-data-table
       :headers="headers" 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -20,6 +20,15 @@
     <AuthN></AuthN>
   </v-app-bar>
 
+  <v-text-field
+    v-model="search"
+    append-icon="mdi-magnify"
+    label="Search"
+    single-line
+    density="comfortable"
+    hide-details
+  ></v-text-field>
+
   <!-- <div v-if="!clickUpUserInfo.length">
     <p>Please register for a KAI ClickUp account to use this application</p>
   </div> -->
@@ -30,7 +39,8 @@
       :items-length="totalItems"
       :items="data" 
       :loading="loading" 
-      class="elevation-1"
+      class="elevation-1 overflow-y-auto"
+      style="max-height: 80vh"
       density="comfortable"
       :search="search"
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
@@ -46,16 +56,6 @@
       @click:row="(pointerEvent, {item}) => editItem(item.raw)"
     > -->
       <template v-slot:top>
-
-        <v-text-field
-          v-model="search"
-          append-icon="mdi-magnify"
-          label="Search"
-          single-line
-          density="comfortable"
-          hide-details
-        ></v-text-field>
-
         <!-- <v-toolbar flat> -->
 
           <v-dialog v-model="dialog" max-width="800px">

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -394,6 +394,7 @@ const onSubmitMsg = computed(() => {
 })
 
 // computed value for toggling group-by behavior
+// if we are using this, will need to pass :group-by="groupBy" prop in <v-data-table-server> component
 const groupBy = computed(() => {
   if(!filterByUser.value){
     return [{key: 'assignees'}]

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -395,7 +395,7 @@ const onSubmitMsg = computed(() => {
 })
 
 // computed value for toggling group-by behavior
-// if we are using this, will need to pass :group-by="groupBy" prop in <v-data-table-server> component
+// if we still plan to incorporate grouping, then we will need to pass a :group-by="groupBy" prop in the <v-data-table-server> component
 const groupBy = computed(() => {
   if(!filterByUser.value){
     return [{key: 'assignees'}]


### PR DESCRIPTION
This PR does the following:
- Converts the original v-data-table to v-data-table-server for proper data retrieval. 
- Changes pagination strategy since ClickUp API does not return the total number of pages available in the GET request.
- Disables the search bar temporarily while a team plan's what to do with it, since ClickUp API does not provide a query string parameter to search for tasks by task name.