### PR TITLE
Enable the selection of "Status"

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -111,8 +111,7 @@
                       </v-col>
 
                       <v-col v-if="editedIndex > -1" cols="12" sm="6" md="6">
-                        <v-select v-model="editedItem.status" label="Status" items="" item-title="title"
-                          item-value="value" disabled></v-select>
+                        <v-select v-model="editedItem.status" label="Status" :items="statuses" item-title="status" item-value="status"></v-select>
                       </v-col>
                       <v-col cols="12" sm="6" md="6">
                         <v-select v-model="editedItem.assignees" label="Assignee(s)" :items="members" item-title="title" item-value="value" multiple chips clearable></v-select>
@@ -349,6 +348,18 @@ const priorities = [
   { priority: 'Normal', id: 3, color: '#6fddff' },
   { priority: 'High', id: 2, color: '#ffcc00' },
   { priority: 'Urgent', id: 1, color: '#f50000' },
+]
+
+const statuses = [
+  { status: 'Init request' },
+  { status: 'In progress' },
+  { status: 'Internal QC' },
+  { status: 'Post production' },
+  { status: 'Client review' },
+  { status: 'On-Hold' },
+  { status: 'Scheduled' },
+  { status: 'Done' },
+  { status: 'Complete' },
 ]
 
 // computed value for form title

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -591,7 +591,6 @@ function editItem(item) {
     editedItem.value.due_date = convertToDate(item.due_date, "table")
     editedItem.value.time_estimate = millisecondsToHours(item.time_estimate)
   } else {
-    // editedItem.value = Object.assign({status: "Int Request"}, item)
     editedItem.value = Object.assign({}, item)
   }
 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -111,7 +111,7 @@
                       </v-col>
 
                       <v-col v-if="editedIndex > -1" cols="12" sm="6" md="6">
-                        <v-select v-model="editedItem.status" label="Status" :items="statuses" item-title="status" item-value="status"></v-select>
+                        <v-select v-model="editedItem.status" label="Status" :items="statuses" item-title="title" item-value="value"></v-select>
                       </v-col>
                       <v-col cols="12" sm="6" md="6">
                         <v-select v-model="editedItem.assignees" label="Assignee(s)" :items="members" item-title="title" item-value="value" multiple chips clearable></v-select>
@@ -262,6 +262,7 @@ const submitBtnDisabled = ref(false)
 const submitStatusOverlay = ref(false)
 const submitStatus = ref('')
 const submitErrorInfo = ref('')
+const statuses = ref([])
 
 const headers = [
   { title: 'Name', key: 'name', align: 'start', width: '25%' },
@@ -348,18 +349,6 @@ const priorities = [
   { priority: 'Normal', id: 3, color: '#6fddff' },
   { priority: 'High', id: 2, color: '#ffcc00' },
   { priority: 'Urgent', id: 1, color: '#f50000' },
-]
-
-const statuses = [
-  { status: 'Init request' },
-  { status: 'In progress' },
-  { status: 'Internal QC' },
-  { status: 'Post production' },
-  { status: 'Client review' },
-  { status: 'On-Hold' },
-  { status: 'Scheduled' },
-  { status: 'Done' },
-  { status: 'Complete' },
 ]
 
 // computed value for form title
@@ -471,6 +460,7 @@ onMounted(() => {
   loadTags()
   loadMembers()
   loadFolders()
+  loadStatuses()
 })
 
 // function loadItems({ page }) {
@@ -578,6 +568,30 @@ function loadLists(presentFolderId) {
   .catch(err => console.log(err))
 }
 
+function loadStatuses() {
+  // some endpoint will go here
+
+  // simulate axios response
+  let response = [
+    { "status": "init request", "color": "#d3d3d3", "type": "open", "orderindex": 0 },
+    { "status": "in progress", "color": "#7C4DFF", "type": "custom", "orderindex": 1 },
+    { "status": "internal qc", "color": "#02BCD4", "type": "custom", "orderindex": 2 },
+    { "status": "post production", "color": "#AABC1E", "type": "custom", "orderindex": 3 },
+    { "status": "client review", "color": "#EE70C7", "type": "custom","orderindex": 4 },
+    { "status": "on-hold", "color": "#e50000", "type": "custom", "orderindex": 5 },
+    { "status": "scheduled", "color": "#2BAA76", "type": "done", "orderindex": 6 },
+    { "status": "done", "color": "#2ecd6f", "type": "done", "orderindex": 7 },
+    { "status": "complete", "color": "#6bc950", "type": "closed", "orderindex": 8 }
+  ]
+
+  statuses.value = response.map((item) => {
+    return {
+      title: capitalizeFirstLetter(item.status),
+      value: item.status,
+    }
+  })
+}
+
 function editItem(item) {
   editedIndex.value = data.value.indexOf(item)
 
@@ -586,7 +600,6 @@ function editItem(item) {
     loadFolders()
     loadLists(item.folder)
     editedItem.value = Object.assign({}, item)
-    editedItem.value.status = capitalizeFirstLetter(item.status)
     editedItem.value.priority = (item.priority != null) ? capitalizeFirstLetter(item.priority.priority) : null
     editedItem.value.due_date = convertToDate(item.due_date, "table")
     editedItem.value.time_estimate = millisecondsToHours(item.time_estimate)


### PR DESCRIPTION
This PR does the following: 
- Enables the user to select a work order status.
- Until the API can provide a GET endpoint for statuses, we will simulate the response data using static data. Logic has been re-worked in preparation for the endpoint. Once it is available, simply configure the axios request accordingly.