### PR TITLE
Changes task estimate label, and fix defect which prevented users with capital letters in email from seeing app

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -436,7 +436,7 @@ onBeforeMount(() => {
 })
 
 function loadClickUpUserInfo() {
-  axios.get(`${runtimeConfig.public.API_URL}/members/?email=` + authStore.currentUser.username)
+  axios.get(`${runtimeConfig.public.API_URL}/members/?email=` + authStore.currentUser.username.toLowerCase())
   .then((response) => {
     clickUpUserInfo.value = response.data.data[0]
   })

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -125,7 +125,7 @@
                       </v-col>
 
                       <v-col cols="12" sm="6" md="6">
-                        <v-text-field v-model="editedItem.time_estimate" label="Hours Allocated"></v-text-field>
+                        <v-text-field v-model="editedItem.time_estimate" label="Budgeted Hours"></v-text-field>
                       </v-col>
                       <v-col cols="12" sm="6" md="6">
                         <v-select v-model="editedItem.priority" label="Priority" :items="priorities" item-title="title" item-value="value"></v-select>


### PR DESCRIPTION
This PR does the following:
- Changes "Hours Allocated" label to "Budgeted Hours"
- Fixes a defect where if user's active directory email address has capital letters, it prevented them from seeing the app. API is case-sensitive when querying for ClickUp users.