### PR TITLE
Add filters to hide/show "Completed" work orders

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -10,6 +10,8 @@
     <v-list color="transparent">
       <v-list-item prepend-icon="mdi-account-box" title="My work orders" @click="filterByUserToggle('user')"></v-list-item>
       <v-list-item prepend-icon="mdi-account-box-multiple" title=" All work orders" @click="filterByUserToggle('all')"></v-list-item>
+      <v-list-item prepend-icon="mdi-format-list-bulleted" title="Not completed" @click="toggleShowCompleted(false)"></v-list-item>
+      <v-list-item prepend-icon="mdi-playlist-check" title="Completed" @click="toggleShowCompleted(true)"></v-list-item>
       <v-list-item prepend-icon="mdi-form-select" title="Add New Work Order" @click="editItem(item)"></v-list-item>
     </v-list>
   </v-navigation-drawer>
@@ -244,6 +246,7 @@ const editedIndex = ref(-1)
 const data = ref([])
 const search = ref('')
 const filterByUser = ref(true)
+const showCompleted = ref(false)
 const drawer = ref(false)
 const form = ref(null)
 const tags = ref([])
@@ -478,6 +481,9 @@ function loadItems() {
 
   // set filters
   if(filterByUser.value) axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + clickUpUserInfo.value.id
+
+  // TODO: construct an array of all available statuses except complete
+  // if(showCompleted.value) axiosGetRequestURL = axiosGetRequestURL + `&statuses[]=complete`
 
   axios.get(axiosGetRequestURL)
   .then((response) => {
@@ -729,6 +735,15 @@ function filterByUserToggle (type) {
   } 
 
   loadItems()
+}
+
+function toggleShowCompleted (value) {
+  if(value != showCompleted.value) {
+    showCompleted.value = (value) ? true : false
+    // loadItems()
+  } else {
+    return
+  }
 }
 
 function incrementPage() {

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -479,22 +479,18 @@ function loadItems() {
   loading.value = true
   let axiosGetRequestURL = `${runtimeConfig.public.API_URL}/tasks/?page=` + page.value
 
-  // set filters
+  // set assignee filter
   if(filterByUser.value) axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + clickUpUserInfo.value.id
 
   // set display completed work order filter
   if(showCompleted.value) {
     axiosGetRequestURL = axiosGetRequestURL + `&statuses[]=complete`
   } else {
-    let statusesArray = []
-    statuses.value.forEach(status => 
-      statusesArray.push(status.value)
-    )
-    statusesArray = statusesArray.filter(e => e !== 'complete')
+    const statusesArray = statuses.value.filter(e => e.value !== 'complete')
 
     let statusQueryStr = ''
     statusesArray.forEach(element => 
-      statusQueryStr += '&statuses[]=' + encodeURIComponent(element)
+      statusQueryStr += '&statuses[]=' + encodeURIComponent(toRaw(element).value)
     )
 
     axiosGetRequestURL = axiosGetRequestURL + statusQueryStr

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -8,8 +8,8 @@
     hide-overlay
   >
     <v-list color="transparent">
-      <v-list-item prepend-icon="mdi-account-box" title="My work orders" @click="filterByUserToggle('user')"></v-list-item>
-      <v-list-item prepend-icon="mdi-account-box-multiple" title=" All work orders" @click="filterByUserToggle('all')"></v-list-item>
+      <v-list-item prepend-icon="mdi-account-box" title="My work orders" @click="toggleShowUsersWorkOrders(true)"></v-list-item>
+      <v-list-item prepend-icon="mdi-account-box-multiple" title=" All work orders" @click="toggleShowUsersWorkOrders(false)"></v-list-item>
       <v-list-item prepend-icon="mdi-format-list-bulleted" title="Not completed" @click="toggleShowCompleted(false)"></v-list-item>
       <v-list-item prepend-icon="mdi-playlist-check" title="Completed" @click="toggleShowCompleted(true)"></v-list-item>
       <v-list-item prepend-icon="mdi-form-select" title="Add New Work Order" @click="editItem(item)"></v-list-item>
@@ -743,14 +743,13 @@ function save() {
 
 }
 
-function filterByUserToggle (type) {
-  if(type === 'user') {
-    filterByUser.value = true
+function toggleShowUsersWorkOrders (value) {
+  if(value != filterByUser.value) {
+    filterByUser.value = (value) ? true : false
+    loadItems()
   } else {
-    filterByUser.value = false
-  } 
-
-  loadItems()
+    return
+  }
 }
 
 function toggleShowCompleted (value) {

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -482,8 +482,23 @@ function loadItems() {
   // set filters
   if(filterByUser.value) axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + clickUpUserInfo.value.id
 
-  // TODO: construct an array of all available statuses except complete
-  // if(showCompleted.value) axiosGetRequestURL = axiosGetRequestURL + `&statuses[]=complete`
+  // set display completed work order filter
+  if(showCompleted.value) {
+    axiosGetRequestURL = axiosGetRequestURL + `&statuses[]=complete`
+  } else {
+    let statusesArray = []
+    statuses.value.forEach(status => 
+      statusesArray.push(status.value)
+    )
+    statusesArray = statusesArray.filter(e => e !== 'complete')
+
+    let statusQueryStr = ''
+    statusesArray.forEach(element => 
+      statusQueryStr += '&statuses[]=' + encodeURIComponent(element)
+    )
+
+    axiosGetRequestURL = axiosGetRequestURL + statusQueryStr
+  }
 
   axios.get(axiosGetRequestURL)
   .then((response) => {
@@ -740,7 +755,7 @@ function filterByUserToggle (type) {
 function toggleShowCompleted (value) {
   if(value != showCompleted.value) {
     showCompleted.value = (value) ? true : false
-    // loadItems()
+    loadItems()
   } else {
     return
   }

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -486,6 +486,11 @@ function loadItems() {
   if(showCompleted.value) {
     axiosGetRequestURL = axiosGetRequestURL + `&statuses[]=complete`
   } else {
+    /* 
+      since the API doesn't have the capability to accept a NOT operator in the query string,
+      we will need to filter out status of "complete" here.
+      if/when it does, then mimic assignee filter logic.
+    */
     const statusesArray = statuses.value.filter(e => e.value !== 'complete')
 
     let statusQueryStr = ''


### PR DESCRIPTION
This PR accomplishes the following:
- Add controls to allow users to hide/show work orders with a status of "complete".
- Prevents the app from reloading data if filters for user or complete-status are already set, and user attempts to re-apply them.