### PR TITLE
Display record creator on data table and fix epoch start date issue

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -265,6 +265,7 @@ const priorities = ref([])
 const headers = [
   { title: 'Name', key: 'name', align: 'start', width: '25%' },
   { title: 'Project', key: 'project', align: 'start', sortable: false },
+  { title: 'Created By', key: 'creator', align: 'start', sortable: false },
   { title: 'Assignee(s)', key: 'assignees', align: 'start', sortable: false },
   { title: 'Type', key: 'tags', align: 'start', sortable: false },
   { title: 'Status', key: 'status', align: 'start', sortable: false },
@@ -507,6 +508,7 @@ function loadItems() {
     data.value = response.data.data.map((item) => {
       return {
         assignees: item.assignees,
+        creator: item.creator.username,
         list: item.list.id,
         description: item.description,
         due_date: item.due_date,

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -175,6 +175,10 @@
         <!-- </v-toolbar> -->
       </template>
 
+      <template v-slot:item.creator="{ item }">
+        {{ item.raw.creator.username }}
+      </template>
+
       <template v-slot:item.assignees="{ item }">
         <v-chip v-for="assignee in item.raw.assignees">{{ (!assignee.username) ? assignee.email : assignee.username }}</v-chip>
       </template>
@@ -508,7 +512,7 @@ function loadItems() {
     data.value = response.data.data.map((item) => {
       return {
         assignees: item.assignees,
-        creator: item.creator.username,
+        creator: item.creator,
         list: item.list.id,
         description: item.description,
         due_date: item.due_date,

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -643,7 +643,7 @@ function editItem(item) {
     loadLists(item.folder)
     editedItem.value = Object.assign({}, item)
     editedItem.value.priority = (item.priority != null) ? capitalizeFirstLetter(item.priority.priority) : null
-    editedItem.value.due_date = convertToDate(item.due_date, "table")
+    editedItem.value.due_date = (item.due_date != null) ? convertToDate(item.due_date, "table") : null
     editedItem.value.time_estimate = millisecondsToHours(item.time_estimate)
 
     // get list of watchers and assign it to the editedItem object


### PR DESCRIPTION
This PR does this following:
- Displays the record creator within the data table.
- Fixes a bug where "12/31/1969" was being displayed in the "edit work order form" whenever the due_date value was null.