### PR TITLE
Bug fix: Flickering issue when loading the Edit Work Order form

### DIFF
--- a/components/FormComponent.vue
+++ b/components/FormComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- TODO: need to fix flickering issue -->
-  <div v-if="loading && props.recordId">
+  <div v-if="loading">
     Retrieving data ...
   </div>
   <div v-else>
@@ -270,9 +270,9 @@ onMounted(() => {
 async function loadItem() {
   // convert time estimate (milliseconds) to hours if not a new work order
   if (props.recordId) {
-    loading.value = true
     await axios.get(`${runtimeConfig.public.API_URL}/task/` + props.recordId)
     .then((response) => {
+      loading.value = true
       editedItem.value = Object.assign({}, response.data.data)
       editedItem.value.priority = (response.data.data.priority != null) ? capitalizeFirstLetter(response.data.data.priority.priority) : null
       editedItem.value.due_date = (response.data.data.due_date != null) ? convertToDate(response.data.data.due_date, "table") : null
@@ -294,8 +294,6 @@ async function loadItem() {
       folderIDTemp.value = editedItem.value.folder.id
 
       loadLists(editedItem.value.folder.id)
-
-      loading.value = false
     })
     .catch(err => console.log(err))
 
@@ -304,7 +302,9 @@ async function loadItem() {
   } else {
     editedItem.value = Object.assign({}, '')
   }
-  // dialog.value = true
+  setTimeout(() => {
+    loading.value = false
+  }, 500)
 }
 
 function loadTags() {

--- a/components/FormComponent.vue
+++ b/components/FormComponent.vue
@@ -1,6 +1,5 @@
 <template>
-  <!-- TODO: need to fix flickering issue -->
-  <div v-if="loading">
+  <div v-if="loading && props.formAction === 'edit'">
     Retrieving data ...
   </div>
   <div v-else>
@@ -138,6 +137,7 @@ const submitStatus = ref('')
 const submitInfo = ref('')
 const props = defineProps({
     recordId: String,
+    formAction: String,
     clickUpUserInfo: Object,
 })
 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -62,7 +62,7 @@
               </v-col>
             </template> -->
 
-            <form-component :clickUpUserInfo="clickUpUserInfo" @close="close()"></form-component>
+            <form-component form-action="new" :clickUpUserInfo="clickUpUserInfo" @close="close()"></form-component>
           </v-dialog>
         <!-- </v-toolbar> -->
       </template>

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -4,7 +4,7 @@
 -->
 <template>
   <div>
-    <form-component :record-id="route.query.id" :clickUpUserInfo="clickUpUserInfo"></form-component>
+    <form-component form-action="edit" :record-id="route.query.id" :clickUpUserInfo="clickUpUserInfo"></form-component>
   </div>
 </template>
 


### PR DESCRIPTION
This PR fixes a flickering issue while loading the "Edit Work Order" form. 
- A timeout of .5 seconds (500ms) is added before displaying the form in both New and Edit scenarios.
- An additional "formAction" prop is accepted by FormComponent to help with conditional to display loading message.