### PR TITLE
Display a loading overlay while data is fetched. Bug fixes.

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,6 +16,19 @@
     </div>
   </div>
   <div v-else>
+    <v-overlay v-model="displayLoadingMessage" class="align-center justify-center" persistent>
+      <v-container style="height: 400px;">
+        <v-row class="fill-height" align-content="center" justify="center">
+          <v-col class="text-subtitle-1 text-center" cols="12">
+            <v-card style="font-family:'Open Sans;'">
+              <v-card-text>Retrieving data...</v-card-text>
+              <v-progress-circular color="#92D5D5" indeterminate size="50" class="mb-4"></v-progress-circular>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-overlay>
+
     <v-layout>
       <v-main style="min-height: 300px;">
         <div>
@@ -107,6 +120,9 @@
   const userInfoStore = useUserInfoStore()
   const route = useRoute()
   const drawer = ref(true)
+
+  const displayLoadingMessage = ref(false)
+  provide('displayLoadingMessage', displayLoadingMessage)
 
   // use provide/inject pattern to send data to child component
   const showModal = ref(false)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,7 +16,11 @@
     </div>
   </div>
   <div v-else>
-    <v-overlay v-model="displayLoadingMessage" class="align-center justify-center" persistent>
+    <!-- 
+      only show this loader on non-record pages since those have their own loader.
+      maybe look at integrating later on.
+     -->
+    <v-overlay v-if="!isRecordPage" v-model="displayLoadingMessage" class="align-center justify-center" persistent>
       <v-container style="height: 400px;">
         <v-row class="fill-height" align-content="center" justify="center">
           <v-col class="text-subtitle-1 text-center" cols="12">

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -3,6 +3,19 @@
   both root index.vue and /workorders/index.vue utilize it
 -->
 <template>
+  <v-overlay v-model="loading" class="align-center justify-center" persistent>
+    <v-container style="height: 400px;">
+      <v-row class="fill-height" align-content="center" justify="center">
+        <v-col class="text-subtitle-1 text-center" cols="12">
+          <v-card style="font-family:'Open Sans;'">
+            <v-card-text>Retrieving data...</v-card-text>
+            <v-progress-circular color="#92D5D5" indeterminate size="50" class="mb-4"></v-progress-circular>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-overlay>
+
   <work-order-system v-if="!loading" :statuses="statuses" :persons="persons"></work-order-system>
 </template>
 

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -3,19 +3,6 @@
   both root index.vue and /workorders/index.vue utilize it
 -->
 <template>
-  <v-overlay v-model="loading" class="align-center justify-center" persistent>
-    <v-container style="height: 400px;">
-      <v-row class="fill-height" align-content="center" justify="center">
-        <v-col class="text-subtitle-1 text-center" cols="12">
-          <v-card style="font-family:'Open Sans;'">
-            <v-card-text>Retrieving data...</v-card-text>
-            <v-progress-circular color="#92D5D5" indeterminate size="50" class="mb-4"></v-progress-circular>
-          </v-card>
-        </v-col>
-      </v-row>
-    </v-container>
-  </v-overlay>
-
   <work-order-system v-if="!loading" :statuses="statuses" :persons="persons"></work-order-system>
 </template>
 
@@ -31,9 +18,13 @@ const { $msal } = useNuxtApp()
 const runtimeConfig = useRuntimeConfig()
 const statuses = ref()
 const persons = ref()
-const loading = ref(true)
+const loading = inject('displayLoadingMessage')
+const isRecordPage = inject('isRecordPage')
 
 onBeforeMount(async () => {
+  // only display loader overlay when not on a record page
+  loading.value = (!isRecordPage.value) ? true : false
+
   if(userInfoStore.userInfo.id.length < 1) {
     try {
       const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -8,11 +8,12 @@
 
 <script setup>
 import { useAuthStore } from '~/store/auth';
+import { useUserInfoStore } from '~/store/userInfoStore'
 import axios from 'axios'
 import { capitalizeFirstLetter } from '~/helpers/capitalizeFirstLetter.js';
 
-
 const authStore = useAuthStore()
+const userInfoStore = useUserInfoStore()
 const { $msal } = useNuxtApp()
 const runtimeConfig = useRuntimeConfig()
 const statuses = ref()
@@ -20,6 +21,15 @@ const persons = ref()
 const loading = ref(true)
 
 onBeforeMount(async () => {
+  if(userInfoStore.userInfo.id.length < 1) {
+    try {
+      const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())
+      userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
   try {
     const response = await axios.get(`${runtimeConfig.public.API_URL}/statuses`)
       statuses.value = response.data.data.map((item) => {

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -22,8 +22,7 @@ const loading = inject('displayLoadingMessage')
 const isRecordPage = inject('isRecordPage')
 
 onBeforeMount(async () => {
-  // only display loader overlay when not on a record page
-  loading.value = (!isRecordPage.value) ? true : false
+  loading.value = true
 
   if(userInfoStore.userInfo.id.length < 1) {
     try {


### PR DESCRIPTION
This PR does the following:
- Will now display a loading spinner upon login.
- Fixes an issue where if user's first page is /workorders, they were not seeing data.