### PR TITLE
Archived Projects logic and update Vuetify to v3.3.10

### DIFF
--- a/components/CommentsComp.vue
+++ b/components/CommentsComp.vue
@@ -12,9 +12,9 @@
             <v-list-item v-else>No comments</v-list-item>
         </v-list>
 
-        <v-divider :thickness="3"></v-divider>
+        <v-divider v-if="!readonly" :thickness="3"></v-divider>
 
-        <v-form ref="form" @submit.prevent="submitComment">
+        <v-form v-if="!readonly" ref="form" @submit.prevent="submitComment">
             <v-row class="pl-3 pr-3">
                 <v-col cols="12" sm="12" md="12">
                     <v-text-field v-model="commentForm.message" class="pt-5" placeholder="Enter a comment" outlined clearable></v-text-field>
@@ -40,8 +40,10 @@ const commentsData = ref([])
 
 const props = defineProps({
     workorderid: String,
+    readonly: Boolean,
 })
 const { workorderid } = toRefs(props);
+const { readonly } = toRefs(props);
 
 const commentForm = ref({
     authorid: userInfoStore.userInfo.id,

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -52,7 +52,7 @@
               <v-btn href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
             </v-col>
 
-            <v-col cols="12" sm="12" md="12">
+            <v-col v-if="props.recordId" cols="12" sm="12" md="12">
               <v-checkbox v-model="editedItem.isarchived" label="Archived" true-value="1" false-value="0"></v-checkbox>
             </v-col>
           </v-row>

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -35,7 +35,7 @@
       </v-card-title>
 
       <v-card-text>
-        <v-form ref="form" @submit.prevent="submit">
+        <v-form ref="form" @submit.prevent="submit" :readonly="readonly">
           <v-row>
             <v-col cols="12" sm="12" md="12">
               <v-text-field v-model="editedItem.name" label="Project" 
@@ -49,11 +49,11 @@
 
             <v-col cols="12" sm="12" md="12">
               <v-text-field v-model="editedItem.link" label="SharePoint Link"></v-text-field>
-              <v-btn href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
+              <v-btn v-if="!readonly" href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
             </v-col>
 
             <v-col v-if="props.recordId" cols="12" sm="12" md="12">
-              <v-checkbox v-model="editedItem.isarchived" label="Archived" true-value="1" false-value="0"></v-checkbox>
+              <v-checkbox v-model="editedItem.isarchived" label="Archived" true-value="1" false-value="0" :readonly="readonly"></v-checkbox>
             </v-col>
           </v-row>
         </v-form>
@@ -63,7 +63,7 @@
         <v-row>
           <v-col class="text-right">
             <v-btn variant="plain" @click="close" title="Cancel">Cancel</v-btn>
-            <v-btn :disabled="submitBtnDisabled" class="rounded" color="blue" @click="submit" :title="`${ submitBtnText } project`">{{ submitBtnText }}</v-btn>
+            <v-btn v-if="!readonly" :disabled="submitBtnDisabled" class="rounded" color="blue" @click="submit" :title="`${ submitBtnText } project`">{{ submitBtnText }}</v-btn>
           </v-col>
         </v-row>
       </v-card-actions>
@@ -81,6 +81,7 @@ const submitStatus = ref('')
 const submitInfo = ref('')
 const loading = ref(true)
 const confirmArchiveOverlay = ref(false)
+const readonly = ref(false)
 
 const props = defineProps({
     recordId: String,
@@ -101,7 +102,8 @@ const editedItem = ref([
 
 // computed value for form title
 const formTitle = computed(() => {
-  return (!props.recordId) ? 'New Project Form' : 'Edit Project Form'
+  return (!props.recordId) ? 'New Project Form' : 
+    (readonly.value) ? 'Archived Project Information' : 'Edit Project Form'
 })
 
 // computed value for save/submit button text
@@ -163,6 +165,11 @@ function closeArchiveConfirmationModal() {
 
 onMounted(async () => {
   await loadItem()
+
+  // set form to readonly state if on a record page and project is archived
+  if(props.recordId && editedItem.value.isarchived === '1') {
+    readonly.value = true
+  }
 })
 
 async function loadItem() {

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -369,7 +369,10 @@ function loadProjects() {
   // load project options
   axios.get(`${runtimeConfig.public.API_URL}/projects`)
   .then((response) => {
-    projects.value = response.data.data.map((item) => {
+    // change project.name to project.isarchived
+    const filteredResponse = response.data.data.filter(item => item.name !== 'Archived Project')
+
+    projects.value = filteredResponse.map((item) => {
       return {
         id: item.id,
         name: item.name

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -107,7 +107,7 @@
       <v-window-item v-if="props.recordId" value="two">
         <v-card>
           <v-card-text>
-            <comments-comp :workorderid="props.recordId"></comments-comp>
+            <comments-comp :workorderid="props.recordId" :readonly="readonly"></comments-comp>
           </v-card-text>
         </v-card>
         

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -269,8 +269,9 @@ onBeforeMount(() => {
 onMounted(async () => {
   await loadItem()
 
+  // if on a record page, check if project is archived
   // change project.name to project.isarchived
-  if(editedItem.value.project.name === 'Archived Project') {
+  if(props.recordId && editedItem.value.project.name === 'Archived Project') {
     readonly.value = true
   }
 })

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -35,7 +35,7 @@
           </v-card-title>
 
           <v-card-text>
-            <v-form ref="form" @submit.prevent="submit">
+            <v-form ref="form" @submit.prevent="submit" :readonly="readonly">
               <v-row>
                 <v-col cols="12" sm="12" md="12">
                   <v-text-field v-model="editedItem.name" label="Name" 
@@ -97,7 +97,7 @@
             <v-row>
               <v-col class="text-right">
                 <v-btn variant="plain" @click="close" title="Cancel">Cancel</v-btn>
-                <v-btn :disabled="submitBtnDisabled" class="rounded" color="blue" @click="submit" :title="`${ submitBtnText } work order`">{{ submitBtnText }}</v-btn>
+                <v-btn v-if="!readonly" :disabled="submitBtnDisabled" class="rounded" color="blue" @click="submit" :title="`${ submitBtnText } work order`">{{ submitBtnText }}</v-btn>
               </v-col>
             </v-row>
           </v-card-actions>
@@ -137,6 +137,7 @@ const subtasks = ref([])
 const priorities = ref([])
 const form = ref(null)
 const formTab = ref(null)
+const readonly = ref(false)
 const submitBtnDisabled = ref(false)
 const submitStatusOverlay = ref(false)
 const submitStatus = ref('')
@@ -273,6 +274,11 @@ onBeforeMount(() => {
 
 onMounted(async () => {
   await loadItem()
+
+  // change project.name to project.isarchived
+  if(editedItem.value.project.name === 'Archived Project') {
+    readonly.value = true
+  }
 })
 
 async function loadItem() {

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -80,8 +80,8 @@
                 </v-col>
 
                 <v-col cols="12" sm="12" md="12" class="mt-5">
-                  <v-text-field v-model="editedItem.links" label="SharePoint File"></v-text-field>
-                  <v-btn href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
+                  <v-text-field v-model="editedItem.links" label="SharePoint Link"></v-text-field>
+                  <v-btn v-if="!readonly" href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
                 </v-col>
               </v-row>
             </v-form>
@@ -167,7 +167,8 @@ const editedItem = ref([
 
 // computed value for form title
 const formTitle = computed(() => {
-  return (!props.recordId) ? 'New Work Order Form' : 'Edit Work Order Form'
+  return (!props.recordId) ? 'New Work Order Form' : 
+    (readonly.value) ? 'Archived Work Order Details' : 'Edit Work Order Form'
 })
 
 // computed value for save/submit button text
@@ -269,7 +270,7 @@ onBeforeMount(() => {
 onMounted(async () => {
   await loadItem()
 
-  // if on a record page, check if project is archived
+  // set form to readonly state if on a record page and WO project is archived
   // change project.name to project.isarchived
   if(props.recordId && editedItem.value.project.name === 'Archived Project') {
     readonly.value = true

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -45,6 +45,10 @@
             </v-dialog>
           </template>
 
+          <template v-slot:item.project="{ item }">
+            {{ item.raw.project.name + ' | ' + item.raw.subtask.name  }}
+          </template>
+
           <template v-slot:item.creator="{ item }">
             {{ item.raw.creator.name }}
           </template>
@@ -82,7 +86,11 @@
           </template>
 
           <template v-slot:item.actions="{ item }">
-            <NuxtLink :to="'/workorders?id=' + item.raw.id" title="View and edit work order">
+            <!-- change project.name to project.isarchived -->
+            <NuxtLink v-if="item.raw.project.name === 'Archived Project'" :to="'/workorders?id=' + item.raw.id" title="View work order">
+              <v-icon size="small" class="me-2">mdi-list-box-outline</v-icon>
+            </NuxtLink>
+            <NuxtLink v-else :to="'/workorders?id=' + item.raw.id" title="View and edit work order">
               <v-icon size="small" class="me-2">mdi-pencil</v-icon>
             </NuxtLink>
           </template>
@@ -253,7 +261,6 @@ function loadItems() {
 
   axios.get(axiosGetRequestURL)
   .then((response) => {
-    // data.value = response.data.data.slice(0, 10).map((item) => {
     data.value = response.data.data.map((item) => {
       return {
         assignees: item.assignees,
@@ -264,10 +271,7 @@ function loadItems() {
         links: item.links,
         name: item.name,
         priority: item.priority,
-
-        // since this not in a pill, need to do this way
-        // some projects/subtasks come in as NULL
-        project: (item.project) ? item.project.name + ' | ' + item.subtask.name : '',
+        project: item.project,
         status: item.status,
         subtask: item.subtask,
         tags: item.tags,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "pinia": "^2.0.35",
         "sass": "^1.62.1",
         "vite-plugin-vuetify": "^1.0.2",
-        "vuetify": "^3.3.2"
+        "vuetify": "^3.3.10"
       },
       "devDependencies": {
         "@nuxt/image-edge": "^1.0.0-28059208.2abef1b",
@@ -8524,9 +8524,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.2.tgz",
-      "integrity": "sha512-m/R42di8FlyMaoktUe6k8JbF+A0vbJMpjQrZK7nH1ptK8VinVVQcaw+9m94wlO74IMR+LubxLh5t9I2ZtVCvjw==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.10.tgz",
+      "integrity": "sha512-jV5zA4PMK1ik8j/alPhAR75fzSoAvUgPcoKl+fZ/buDu70vJ3nM6+F3zh78UBs0PMzyLlarwt851QNbYXLbZbQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "pinia": "^2.0.35",
     "sass": "^1.62.1",
     "vite-plugin-vuetify": "^1.0.2",
-    "vuetify": "^3.3.2"
+    "vuetify": "^3.3.10"
   }
 }

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -38,8 +38,12 @@
             <v-chip v-for="subtask in item.raw.subtasks">{{ subtask.name }}</v-chip>
           </template>
 
+          <template v-slot:item.isarchived="{ item }">
+            {{ (item.raw.isarchived == 0) ? 'No' : 'Yes' }}
+          </template>
+
           <template v-slot:item.actions="{ item }">
-            <NuxtLink v-if="item.raw.isarchived === 'Yes'" :to="'/projects?id=' + item.raw.id" title="View archived project info">
+            <NuxtLink v-if="item.raw.isarchived == 1" :to="'/projects?id=' + item.raw.id" title="View archived project info">
               <v-icon size="small" class="me-2">mdi-list-box-outline</v-icon>
             </NuxtLink>
             <NuxtLink v-else :to="'/projects?id=' + item.raw.id" title="Edit project info">
@@ -94,7 +98,7 @@ function loadItems() {
         id: item.id,
         project: item.name,
         subtasks: item.subtasks,
-        isarchived: (item.isarchived == 0) ? 'No' : 'Yes',
+        isarchived: item.isarchived,
       }
     })
     totalItems.value = response.data.total

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -39,7 +39,10 @@
           </template>
 
           <template v-slot:item.actions="{ item }">
-            <NuxtLink :to="'/projects?id=' + item.raw.id" title="Edit work order">
+            <NuxtLink v-if="item.raw.isarchived === 'Yes'" :to="'/projects?id=' + item.raw.id" title="View archived project info">
+              <v-icon size="small" class="me-2">mdi-list-box-outline</v-icon>
+            </NuxtLink>
+            <NuxtLink v-else :to="'/projects?id=' + item.raw.id" title="Edit project info">
               <v-icon size="small" class="me-2">mdi-pencil</v-icon>
             </NuxtLink>
           </template>
@@ -91,7 +94,7 @@ function loadItems() {
         id: item.id,
         project: item.name,
         subtasks: item.subtasks,
-        isarchived: (item.isarchived == 0) ? 'No' :  'Yes',
+        isarchived: (item.isarchived == 0) ? 'No' : 'Yes',
       }
     })
     totalItems.value = response.data.total

--- a/yarn.lock
+++ b/yarn.lock
@@ -4812,10 +4812,10 @@ vue-router@^4.1.6:
     "@vue/server-renderer" "3.2.47"
     "@vue/shared" "3.2.47"
 
-vuetify@^3.0.0-beta.4, vuetify@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/vuetify/-/vuetify-3.3.2.tgz"
-  integrity sha512-m/R42di8FlyMaoktUe6k8JbF+A0vbJMpjQrZK7nH1ptK8VinVVQcaw+9m94wlO74IMR+LubxLh5t9I2ZtVCvjw==
+vuetify@^3.0.0-beta.4, vuetify@^3.3.10:
+  version "3.3.10"
+  resolved "https://registry.npmjs.org/vuetify/-/vuetify-3.3.10.tgz"
+  integrity sha512-jV5zA4PMK1ik8j/alPhAR75fzSoAvUgPcoKl+fZ/buDu70vJ3nM6+F3zh78UBs0PMzyLlarwt851QNbYXLbZbQ==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR will do the following:
- Puts the Work Order record page form in a readonly state and prevents adding additional comments if its selected project is archived (NOTE that logic is hardcoded to one specific project for now. This is pending endpoint changes which need to include "isarchived" attribute in WO's "project" object).
- Updates Work Order table to show a different action icon and title if WO's project is archived (NOTE that logic is hardcoded to one specific project for now. This is pending endpoint changes which need to include "isarchived" attribute in each WO's "project" object).
- Puts the Project record page form in a readonly state if it is archived.
- Updates Project table to show a different action icon and title if project is archived.
- Updates Vuetify to latest version (3.3.10) to address bugs with v-combobox not working with readonly prop.