### PR TITLE
Integrate POST endpoints for Project and Subtasks, add "Billing Code" field to project form

### DIFF
--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -268,11 +268,10 @@ async function save() {
   submitStatusOverlay.value = true
   submitBtnDisabled.value = true
   let projectId = ''
-  let subtaskPostSuccess = true
-  let internalApiSuccess = true
+  let subtaskPostSuccess = true  // flag for axios request
+  let internalApiSuccess = true  // flag for internal API status (example: axios request can succeed, but API has an internal issue)
 
-  // create a data object that will be passed to API to prevent user from seeing conversions
-  let data = Object.assign({}, editedItem.value)
+  let data = Object.assign({}, editedItem.value)  // create a data object that will be passed to API to prevent user from seeing conversions
 
   let subtasksTemp = []
   editedItem.value.subtasks.forEach((subtask) => {

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -268,6 +268,8 @@ async function save() {
   submitStatusOverlay.value = true
   submitBtnDisabled.value = true
   let projectId = ''
+  let subtaskPostSuccess = true
+  let internalApiSuccess = true
 
   // create a data object that will be passed to API to prevent user from seeing conversions
   let data = Object.assign({}, editedItem.value)
@@ -301,16 +303,21 @@ async function save() {
             'Content-Type': 'application/x-www-form-urlencoded'
           }
         })
-        console.log(subtasksPostRes.data.data)
+
+        if (subtasksPostRes.status !== 200) {
+          subtaskPostSuccess = false
+        }
+
+        if (subtasksPostRes.data.response_code !== 200) {
+          internalApiSuccess = false
+        }
       })
 
       
-
-
-      if (projectPostRes.status === 200 && subtasksPostRes.status === 200) {
-        if (projectPostRes.data.response_code === 200 && subtasksPostRes.data.response_code === 200) {
+      if (projectPostRes.status === 200 && subtaskPostSuccess) {
+        if (projectPostRes.data.response_code === 200 && internalApiSuccess) {
           submitStatus.value = (!props.recordId) ? 'success' : 'updated'
-          submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + response.data.data.id : ''
+          submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + projectId : ''
         } else {
           submitStatus.value = 'internal_api_error'
           submitInfo.value = data
@@ -318,9 +325,9 @@ async function save() {
             console.log('projectPost error')
             console.log(projectPostRes)
           }
-          if (subtasksPostRes.data.response_code !== 200) {
+          if (!internalApiSuccess) {
             console.log('subtasksPost error')
-            console.log(subtasksPostRes)
+            // console.log(subtasksPostRes)
           }
           return
         }
@@ -346,7 +353,6 @@ async function save() {
     //   }
     // })
   } catch (err) {
-    console.log("error")
     submitStatus.value = 'connection_failure'
     submitInfo.value = err
     console.log(err)

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -202,60 +202,6 @@ async function submit() {
 }
 
 
-// function save() {
-//   submitInfo.value = ''
-//   submitStatus.value = 'submitting'
-//   submitStatusOverlay.value = true
-//   submitBtnDisabled.value = true
-//   let method = ''
-//   let url = ''
-
-//   // create a data object that will be passed to API to prevent user from seeing conversions
-//   let data = Object.assign({}, editedItem.value)
-
-//   if (!props.recordId) {
-//     method = 'post'
-//     url = `${runtimeConfig.public.API_URL}/project/`
-//   } else {
-//     let subtasksTemp = []
-//     editedItem.value.subtasks.forEach((subtask) => {
-//       (subtask.name) ? subtasksTemp.push(subtask.name) : subtasksTemp.push(subtask)
-//     })
-//     data.subtasks = subtasksTemp
-
-//     method = 'put'
-//     url = `${runtimeConfig.public.API_URL}/project/` + data.id
-//   }
-
-//   axios({
-//       method: method,
-//       url: url,
-//       data: data,
-//       headers: {
-//         'Content-Type': 'application/x-www-form-urlencoded'
-//       }
-//     })
-//     .then(function (response) {
-//       if (response.status === 200) {
-//         if (response.data.response_code === 200) {
-//           submitStatus.value = (!props.recordId) ? 'success' : 'updated'
-//           submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + response.data.data.id : ''
-//         } else {
-//           submitStatus.value = 'internal_api_error'
-//           submitInfo.value = data
-//           console.log(response)
-//           return
-//         }
-//       }
-//     })
-//     .catch(function (error) {
-//       submitStatus.value = 'connection_failure'
-//       submitInfo.value = error
-//       console.log(error)
-//     })
-// }
-
-
 /*
   Backend is setup in a way that we need to perform two seperate POST request
   - One for Project.
@@ -301,14 +247,6 @@ async function save() {
           }
         })
 
-        // console.log('Project POST response:')
-        // console.log(projectPostRes.status)
-        // console.log(projectPostRes.data.response_code)
-        // console.log('Subtasks POST response:')
-        // console.log(subtasksPostRes.status)
-        // console.log(subtasksPostRes.data.response_code)
-
-
         if (projectPostRes.status === 200 && subtasksPostRes.status === 200) {
           if (projectPostRes.data.response_code === 200 && subtasksPostRes.data.response_code === 200) {
             submitStatus.value = (!props.recordId) ? 'success' : 'updated'
@@ -317,11 +255,9 @@ async function save() {
             submitStatus.value = 'internal_api_error'
             submitInfo.value = data
             if (projectPostRes.data.response_code !== 200) {
-              console.log('projectPost error')
               console.log(projectPostRes)
             }
             if (subtasksPostRes.data.response_code !== 200) {
-              console.log('subtasksPost error')
               console.log(subtasksPostRes)
             }
             return

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -268,8 +268,6 @@ async function save() {
   submitStatusOverlay.value = true
   submitBtnDisabled.value = true
   let projectId = ''
-  let subtaskPostSuccess = true  // flag for axios request
-  let internalApiSuccess = true  // flag for internal API status (example: axios request can succeed, but API has an internal issue)
 
   let data = Object.assign({}, editedItem.value)  // create a data object that will be passed to API to prevent user from seeing conversions
 
@@ -303,54 +301,37 @@ async function save() {
           }
         })
 
-        if (subtasksPostRes.status !== 200) {
-          subtaskPostSuccess = false
-        }
+        // console.log('Project POST response:')
+        // console.log(projectPostRes.status)
+        // console.log(projectPostRes.data.response_code)
+        // console.log('Subtasks POST response:')
+        // console.log(subtasksPostRes.status)
+        // console.log(subtasksPostRes.data.response_code)
 
-        if (subtasksPostRes.data.response_code !== 200) {
-          internalApiSuccess = false
+
+        if (projectPostRes.status === 200 && subtasksPostRes.status === 200) {
+          if (projectPostRes.data.response_code === 200 && subtasksPostRes.data.response_code === 200) {
+            submitStatus.value = (!props.recordId) ? 'success' : 'updated'
+            submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + projectId : ''
+          } else {
+            submitStatus.value = 'internal_api_error'
+            submitInfo.value = data
+            if (projectPostRes.data.response_code !== 200) {
+              console.log('projectPost error')
+              console.log(projectPostRes)
+            }
+            if (subtasksPostRes.data.response_code !== 200) {
+              console.log('subtasksPost error')
+              console.log(subtasksPostRes)
+            }
+            return
+          }
         }
       })
-
-      
-      if (projectPostRes.status === 200 && subtaskPostSuccess) {
-        if (projectPostRes.data.response_code === 200 && internalApiSuccess) {
-          submitStatus.value = (!props.recordId) ? 'success' : 'updated'
-          submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + projectId : ''
-        } else {
-          submitStatus.value = 'internal_api_error'
-          submitInfo.value = data
-          if (projectPostRes.data.response_code !== 200) {
-            console.log('projectPost error')
-            console.log(projectPostRes)
-          }
-          if (!internalApiSuccess) {
-            console.log('subtasksPost error')
-            // console.log(subtasksPostRes)
-          }
-          return
-        }
-      }
 
     } else {
       // PUT requests here...
     }
-
-
-
-    // .then(function (response) {
-    //   if (response.status === 200) {
-    //     if (response.data.response_code === 200) {
-    //       submitStatus.value = (!props.recordId) ? 'success' : 'updated'
-    //       submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + response.data.data.id : ''
-    //     } else {
-    //       submitStatus.value = 'internal_api_error'
-    //       submitInfo.value = data
-    //       console.log(response)
-    //       return
-    //     }
-    //   }
-    // })
   } catch (err) {
     submitStatus.value = 'connection_failure'
     submitInfo.value = err

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -235,7 +235,7 @@ async function save() {
       const projectPostRes = await axios({
         method: 'POST',
         url: `${runtimeConfig.public.API_URL}/project/`,
-        data: { 'name': data.name, 'link': data.link },
+        data: { 'name': data.name, 'link': data.link, 'billing_code': data.billing_code },
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
         }

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -48,6 +48,11 @@
             </v-col>
 
             <v-col cols="12" sm="12" md="12">
+              <v-text-field v-model="editedItem.billing_code" label="Billing Code" 
+                :rules="[rules.required]"></v-text-field>
+            </v-col>
+
+            <v-col cols="12" sm="12" md="12">
               <v-text-field v-model="editedItem.link" label="SharePoint Link"></v-text-field>
               <v-btn v-if="!readonly" href="https://kauffmaninc.sharepoint.com/" target="_blank" variant="tonal" class="rounded" color="#428086" title="Open SharePoint">Open SharePoint site</v-btn>
             </v-col>
@@ -93,6 +98,7 @@ const editedItem = ref([
     name: '',
     content: '',
     subtasks: '',
+    billing_code: '',
     isarchived: '',
     link: '',
   }

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -119,6 +119,12 @@ function close() {
 }
 
 
+function closeAndReload() {
+  dialog.value = false
+  loadItems()
+}
+
+
 function setMenuItems() {
   let navigationItems = []
   let settingsItems = []


### PR DESCRIPTION
This PR does this following:
- Change Project POST mechanism to work with backend code, since back-end requires 2 POST requests: (one for Project, one **for each** subtask). 
- For subtasks, backend requires each subtask entered to gets its own dedicated POST request. Therefore, we are now iterating the subtask array, and calling the subtask POST endpoint each time.
- Adds "billing_code" field to front end.
- Fixes a bug where project submit status modal was not closing on confirmation click.