### PR TITLE
Add ACLs

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -209,14 +209,11 @@ function setMenuItems(userInfo) {
       { 'label': 'Work Orders', 'destination': '/workorders', 'icon': 'mdi-keyboard-backspace' },
     ]
   } else {
-    // example ACL logic
-    // settingsItems = (userInfo.role = 'manager') ? [] : [
-    //   { 'label': 'Projects', 'destination': '/projects', 'icon': 'mdi-form-select' },
-    // ]
-    settingsItems = [
+    // only show settings menu if current user has the admin role
+    settingsItems = (userInfoStore.userInfo.role === 'admin') ? [
       { 'label': 'Projects', 'destination': '/projects', 'icon': 'mdi-form-select' },
       { 'label': 'Users', 'destination': '/users', 'icon': 'mdi-account-multiple' },
-    ]
+    ] : []
     filterItems = [
       { 'label': 'My Work Orders', 'icon': 'mdi-account-box', 'filter_name': 'filterByUserTrigger', 'filter_value': true },
       { 'label': 'All Work Orders', 'icon': 'mdi-format-list-bulleted', 'filter_name': 'showCompleted', 'filter_value': false },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -166,7 +166,7 @@
     if(authStore.currentUser) {
       try {
         const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())
-        userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email)
+        userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email, response.data.data[0].role)
       } catch (err) {
         console.log(err)
       }

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid fill-height>
+  <v-container v-if="userInfoStore.userInfo.role === 'admin'" fluid fill-height>
     <v-layout child-flex>
       <v-card v-if="route.query.id" width="100vw">
         <form-component-project form-action="edit" :record-id="route.query.id" @close="close()" @closeAndReload="closeAndReload()"></form-component-project>
@@ -66,9 +66,13 @@
 
 <script setup>
 import axios from 'axios'
+import { useAuthStore } from '~/store/auth';
 import { useNavMenuStore } from '~/store/navMenuStore'
+import { useUserInfoStore } from '~/store/userInfoStore'
 
+const authStore = useAuthStore()
 const navMenuStore = useNavMenuStore()
+const userInfoStore = useUserInfoStore()
 const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 const dialog = inject('dialog')
@@ -86,6 +90,22 @@ const headers = [
   { title: 'Actions', key: 'actions', align: 'center', sortable: false },
 ]
 
+
+onBeforeMount(async () => {
+  if(userInfoStore.userInfo.id.length < 1) {
+    try {
+      const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())
+      userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email, response.data.data[0].role)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  // redirect user back to workorder if they're not an admin
+  if (userInfoStore.userInfo.role !== 'admin') {
+    navigateTo('/workorders')
+  }
+})
 
 onMounted(() => {
   setMenuItems()

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-container fluid fill-height>
+    <v-container v-if="userInfoStore.userInfo.role === 'admin'" fluid fill-height>
       <v-layout child-flex>
         <v-card v-if="route.query.id" width="100vw">
           <form-component-user :record-id="route.query.id" @close="close()" @closeAndReload="closeAndReload()"></form-component-user>
@@ -49,9 +49,13 @@
   
   <script setup>
   import axios from 'axios'
+  import { useAuthStore } from '~/store/auth';
   import { useNavMenuStore } from '~/store/navMenuStore'
+  import { useUserInfoStore } from '~/store/userInfoStore'
   
+  const authStore = useAuthStore()
   const navMenuStore = useNavMenuStore()
+  const userInfoStore = useUserInfoStore()
   const route = useRoute()
   const runtimeConfig = useRuntimeConfig()
   const dialog = inject('dialog')
@@ -70,7 +74,22 @@
     { title: 'Actions', key: 'actions', align: 'center', sortable: false },
   ]
   
-  
+  onBeforeMount(async () => {
+    if(userInfoStore.userInfo.id.length < 1) {
+      try {
+        const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())
+        userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email, response.data.data[0].role)
+      } catch (err) {
+        console.log(err)
+      }
+    }
+
+    // redirect user back to workorder if they're not an admin
+    if (userInfoStore.userInfo.role !== 'admin') {
+      navigateTo('/workorders')
+    }
+  })
+
   onMounted(() => {
     setMenuItems()
   })

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -27,7 +27,7 @@ onBeforeMount(async () => {
   if(userInfoStore.userInfo.id.length < 1) {
     try {
       const response = await axios.get(`${runtimeConfig.public.API_URL}/persons?email=` + authStore.currentUser.username.toLowerCase())
-      userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email)
+      userInfoStore.setUserInfo(response.data.data[0].id, response.data.data[0].name, response.data.data[0].email, response.data.data[0].role)
     } catch (err) {
       console.log(err)
     }

--- a/store/userInfoStore.js
+++ b/store/userInfoStore.js
@@ -5,13 +5,15 @@ export const useUserInfoStore = defineStore('userInfoStore', () => {
     const userInfo = ref({
         id: '',
         name: '',
-        email: ''
+        email: '',
+        role: ''
     })
 
-    const setUserInfo = (id, name, email) => {
+    const setUserInfo = (id, name, email, role) => {
         userInfo.value.id = id
         userInfo.value.name = name
         userInfo.value.email = email
+        userInfo.value.role = role
     }
 
     return {


### PR DESCRIPTION
This PR does the following:
- Add ability for userInfoStore to capture logged-in user's role (pulled from DB).
- Restricts non-admin users from accessing /projects and /users pages.
- Redirects non-admin users back to /workorders should they attempt to access /projects and /users via direct URLs.