### PR TITLE
Add capability to update Project and Subtask records

### DIFF
--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -31,6 +31,7 @@
       type="form"
       cardTitle="Edit subtask"
       cancelBtnText="Cancel"
+      cardText="If you need to modify this subtask, delete it and re-enter."
       confirmBtnText="Confirm"
       :fields="editedSubtask"
       @close="closeAndClearEditSubtaskModal"
@@ -59,7 +60,7 @@
 
               <v-combobox v-model="editedItem.subtasks" label="Subtask(s)" placeholder="Type in subtask name, and press Enter, or click away"
                 :items="editedItem.subtasks" item-title="name" item-value="name" :rules="[rules.required, rules.emptyArray]" chips multiple>
-                <template v-if="props.recordId" v-slot:chip="{ item }">
+                <!-- <template v-if="props.recordId" v-slot:chip="{ item }">
                   <v-chip
                     small
                     v-bind="attrs"
@@ -70,8 +71,13 @@
                   >
                     {{ item.raw.name }}
                   </v-chip>
+                </template> -->
+
+                <template v-if="props.recordId" v-slot:chip="{ item }">
+                  <v-chip @click="subtaskClicked(item.raw)">
+                    {{ (item.raw.name) ? item.raw.name : item.raw }}
+                  </v-chip>
                 </template>
-              
               </v-combobox>
               
             </v-col>

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -318,10 +318,21 @@ async function save() {
 
 function subtaskClicked(subtask) {
   // grab the incoming subtask array index
-  subtask.index = editedItem.value.subtasks.map( subtask => subtask.id ).indexOf(subtask.id)
+  let indexValue = editedItem.value.subtasks.map( subtask => subtask.id ).indexOf(subtask.id)
+
+  let subtaskArr = []
+  const editableKeys = ['name'] // pick what fields are needed here...
+  for (const key in subtask) {
+    if(editableKeys.includes(key)) {
+      if (subtask.hasOwnProperty(key)) {
+        const obj = { id: subtask['id'], name: key, value: subtask[key], index: indexValue }
+        subtaskArr.push(obj)
+      }
+    }
+  }
 
   // assign subtask object to reactive field (to be used by form)
-  editedSubtask.value = Object.assign({}, subtask)
+  editedSubtask.value = subtaskArr
 
   // open a modal with a (text) field bound to editedSubtask.value.name property
   editSubtaskOverlay.value = true
@@ -333,11 +344,12 @@ async function updateSubtask(subtask) {
   submitStatus.value = 'submitting'
   submitStatusOverlay.value = true
 
+  // will need to do perform a loop if editing multiple fields at once
   try { 
     const response = await axios({
       method: 'PUT',
-      url: `${runtimeConfig.public.API_URL}/subtask/` + subtask.id,
-      data: { 'name': subtask.name },
+      url: `${runtimeConfig.public.API_URL}/subtask/` + subtask[0].id,
+      data: { 'name': subtask[0].value },
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       }
@@ -348,7 +360,7 @@ async function updateSubtask(subtask) {
         submitStatus.value = 'updated_subtask'
 
         // update subtask name for the given subtask array's index
-        editedItem.value.subtasks[subtask.index].name = subtask.name
+        editedItem.value.subtasks[subtask[0].index].name = subtask[0].value
       } else {
         submitStatus.value = 'internal_api_error'
         submitInfo.value = data

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -381,7 +381,8 @@ function closeArchiveConfirmationModal() {
 
 
 function resetSubmitStatus() {
-  close()
+  if(!props.recordId) close()
+  
   submitStatus.value = ''
   submitStatusOverlay.value = false
   submitBtnDisabled.value = false
@@ -389,12 +390,8 @@ function resetSubmitStatus() {
 
 
 function close() {
-  if (!props.recordId) {
-    if(submitStatus.value === 'success') {
-      emit('closeAndReload')
-    } else {
-      emit('close')
-    }
+  if(submitStatus.value === 'success') {
+    emit('closeAndReload')
   } else {
     emit('close')
   }

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -419,7 +419,7 @@ function resetSubmitStatus() {
   submitStatusOverlay.value = false
   submitBtnDisabled.value = false
 
-  // put form in readonly state after save
+  // put form in readonly state after save if archive flag is set to true
   if(props.recordId) {
     if(editedItem.value.isarchived == 1) {
       readonly.value = true

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -64,7 +64,7 @@
                 {{ subtask.name }}
               </v-chip>
 
-              <v-btn v-if="!readonly" color="blue" variant="plain" @click="displayAddNewSubtaskField=true">
+              <v-btn v-if="!readonly" color="blue" variant="plain" title="Add more subtasks" @click="displayAddNewSubtaskField=true">
                 Add more subtasks
               </v-btn>
             </v-col>

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -403,6 +403,7 @@ function closeAndClearEditSubtaskModal() {
 
 
 function closeArchiveConfirmationModal() {
+  displayAddNewSubtaskField.value = false
   confirmArchiveOverlay.value = false
 }
 

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -327,7 +327,11 @@ function subtaskClicked(subtask) {
 
 
 function updateSubtask(subtask) {
-  console.log(subtask)
+  // update subtask name for the given subtask array's index
+  editedItem.value.subtasks[subtask.index].name = subtask.name
+
+  // close modal and reset field
+  closeAndClearEditSubtaskModal()
 }
 
 

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -67,7 +67,7 @@
                     v-bind="attrs"
                     :input-value="selected"
                     close
-                    @click="subtaskClicked(item.raw)"
+                    @click="openEditSubtaskModal(item.raw)"
                     @click:close="remove(item)"
                   >
                     {{ item.raw.name }}
@@ -75,14 +75,14 @@
                 </template> -->
 
                 <!-- <template v-if="props.recordId" v-slot:chip="{ item }">
-                  <v-chip @click="subtaskClicked(item.raw)">
+                  <v-chip @click="openEditSubtaskModal(item.raw)">
                     {{ (item.raw.name) ? item.raw.name : item.raw }}
                   </v-chip>
                 </template> -->
               </v-combobox>
 
               <v-label>Subtasks: </v-label>
-              <v-chip v-for="subtask in editedItem.subtasks" @click="subtaskClicked(subtask)">
+              <v-chip v-for="subtask in editedItem.subtasks" @click="openEditSubtaskModal(subtask)">
                 {{ subtask.name }}
               </v-chip>
             </v-col>
@@ -342,7 +342,7 @@ async function save() {
 }
 
 
-function subtaskClicked(subtask) {
+function openEditSubtaskModal(subtask) {
   // grab the incoming subtask array index
   let indexValue = editedItem.value.subtasks.map( subtask => subtask.id ).indexOf(subtask.id)
 

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -64,7 +64,7 @@
                 {{ subtask.name }}
               </v-chip>
 
-              <v-btn v-if="!readonly" color="blue" variant="plain" @click="displayAddNewSubtaskField=true" class="text-right">
+              <v-btn v-if="!readonly" color="blue" variant="plain" @click="displayAddNewSubtaskField=true">
                 Add more subtasks
               </v-btn>
             </v-col>

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -58,15 +58,21 @@
                 :items="editedItem.subtasks" item-title="name" item-value="name" :rules="[rules.required, rules.emptyArray]" chips multiple></v-combobox>
             </v-col>
 
-            <v-col v-else cols="12" sm="12" md="12">
-              <v-combobox v-model="editedItem.newSubtasks" label="New subtasks(s)" placeholder="Add new subtasks here"
-                :items="editedItem.newSubtasks" item-title="name" item-value="name" chips multiple>
-              </v-combobox>
-
-              <v-label>Subtasks: </v-label>
+            <v-col v-if="props.recordId" cols="12" sm="12" md="12">
+              <v-label class="mr-2">Subtasks:</v-label>
               <v-chip v-for="subtask in editedItem.subtasks" @click="openEditSubtaskModal(subtask)" :disabled="readonly">
                 {{ subtask.name }}
               </v-chip>
+
+              <v-btn v-if="!readonly" color="blue" variant="plain" @click="displayAddNewSubtaskField=true" class="text-right">
+                Add more subtasks
+              </v-btn>
+            </v-col>
+
+            <v-col v-if="props.recordId && displayAddNewSubtaskField" cols="12" sm="12" md="12">
+              <v-combobox v-model="editedItem.newSubtasks" label="New subtasks(s)" placeholder="Add new subtasks here"
+                :items="editedItem.newSubtasks" item-title="name" item-value="name" chips multiple>
+              </v-combobox>
             </v-col>
 
             <v-col cols="12" sm="12" md="12">
@@ -110,6 +116,7 @@ const loading = ref(true)
 const confirmArchiveOverlay = ref(false)
 const readonly = ref(false)
 const editSubtaskOverlay = ref(false)
+const displayAddNewSubtaskField = ref(false)
 
 const props = defineProps({
     recordId: String,
@@ -286,6 +293,7 @@ async function save() {
               if(props.recordId) {
                 editedItem.value.subtasks.push(subtasksRequestResponse.data.data)
                 delete editedItem.value.newSubtasks
+                displayAddNewSubtaskField.value = false
               }
 
             } else {

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -415,11 +415,18 @@ function closeArchiveConfirmationModal() {
 function resetSubmitStatus() {
   if(!props.recordId) close()
   
-  closeArchiveConfirmationModal()
-
   submitStatus.value = ''
   submitStatusOverlay.value = false
   submitBtnDisabled.value = false
+
+  // put form in readonly state after save
+  if(props.recordId) {
+    if(editedItem.value.isarchived == 1) {
+      readonly.value = true
+    }
+  }
+
+  closeArchiveConfirmationModal()
 }
 
 

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -173,6 +173,8 @@ const onSubmitMsg = computed(() => {
       return 'Project submitted successfully.'
     case 'updated':
       return 'Project updated successfully.'
+    case 'updated_subtask':
+      return 'Subtask updated successfully.'
     default:
       return ''
   }
@@ -326,9 +328,41 @@ function subtaskClicked(subtask) {
 }
 
 
-function updateSubtask(subtask) {
-  // update subtask name for the given subtask array's index
-  editedItem.value.subtasks[subtask.index].name = subtask.name
+async function updateSubtask(subtask) {
+  submitInfo.value = ''
+  submitStatus.value = 'submitting'
+  submitStatusOverlay.value = true
+
+  try { 
+    const response = await axios({
+      method: 'PUT',
+      url: `${runtimeConfig.public.API_URL}/subtask/` + subtask.id,
+      data: { 'name': subtask.name },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    })
+
+    if (response.status === 200) {
+      if (response.data.response_code === 200) {
+        submitStatus.value = 'updated_subtask'
+
+        // update subtask name for the given subtask array's index
+        editedItem.value.subtasks[subtask.index].name = subtask.name
+      } else {
+        submitStatus.value = 'internal_api_error'
+        submitInfo.value = data
+        if (response.data.response_code !== 200) {
+          console.log(response)
+        }
+        return
+      }
+    }
+  } catch (err) {
+    submitStatus.value = 'connection_failure'
+    submitInfo.value = err
+    console.log(err)
+  }
 
   // close modal and reset field
   closeAndClearEditSubtaskModal()

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -306,7 +306,27 @@ async function save() {
       })
 
     } else {
-      // PUT requests here...
+      const projectPutRes = await axios({
+        method: 'PUT',
+        url: `${runtimeConfig.public.API_URL}/project/` + data.id,
+        data: { 'name': data.name, 'link': data.link, 'billing_code': data.billing_code, 'isarchived': data.isarchived },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      })
+
+      if (projectPutRes.status === 200) {
+        if (projectPutRes.data.response_code === 200) {
+          submitStatus.value = 'updated'
+        } else {
+          submitStatus.value = 'internal_api_error'
+          submitInfo.value = data
+          if (projectPutRes.data.response_code !== 200) {
+            console.log(projectPutRes)
+          }
+          return
+        }
+      }
     }
   } catch (err) {
     submitStatus.value = 'connection_failure'
@@ -395,6 +415,8 @@ function closeArchiveConfirmationModal() {
 function resetSubmitStatus() {
   if(!props.recordId) close()
   
+  closeArchiveConfirmationModal()
+
   submitStatus.value = ''
   submitStatusOverlay.value = false
   submitBtnDisabled.value = false

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -61,24 +61,6 @@
             <v-col v-else cols="12" sm="12" md="12">
               <v-combobox v-model="editedItem.newSubtasks" label="New subtasks(s)" placeholder="Add new subtasks here"
                 :items="editedItem.newSubtasks" item-title="name" item-value="name" chips multiple>
-                <!-- <template v-if="props.recordId" v-slot:chip="{ item }">
-                  <v-chip
-                    small
-                    v-bind="attrs"
-                    :input-value="selected"
-                    close
-                    @click="openEditSubtaskModal(item.raw)"
-                    @click:close="remove(item)"
-                  >
-                    {{ item.raw.name }}
-                  </v-chip>
-                </template> -->
-
-                <!-- <template v-if="props.recordId" v-slot:chip="{ item }">
-                  <v-chip @click="openEditSubtaskModal(item.raw)">
-                    {{ (item.raw.name) ? item.raw.name : item.raw }}
-                  </v-chip>
-                </template> -->
               </v-combobox>
 
               <v-label>Subtasks: </v-label>

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -26,6 +26,17 @@
     >
     </modal-comp>
 
+    <modal-comp 
+      v-model="editSubtaskOverlay"
+      type="form"
+      cardTitle="Edit subtask"
+      cancelBtnText="Cancel"
+      confirmBtnText="Confirm"
+      :fields="editedSubtask"
+      @close="closeAndClearEditSubtaskModal"
+      @confirm="updateSubtask"
+    >
+    </modal-comp>
 
     <h3 v-if="props.formAction === 'edit'">{{ formTitle }}</h3>
 
@@ -43,8 +54,26 @@
             </v-col>
 
             <v-col cols="12" sm="12" md="12">
+              <!-- <v-combobox v-model="editedItem.subtasks" label="Subtask(s)" placeholder="Type in subtask name, and press Enter, or click away"
+                :items="editedItem.subtasks" item-title="name" item-value="name" :rules="[rules.required, rules.emptyArray]" chips multiple></v-combobox> -->
+
               <v-combobox v-model="editedItem.subtasks" label="Subtask(s)" placeholder="Type in subtask name, and press Enter, or click away"
-                :items="editedItem.subtasks" item-title="name" item-value="name" :rules="[rules.required, rules.emptyArray]" chips multiple></v-combobox>
+                :items="editedItem.subtasks" item-title="name" item-value="name" :rules="[rules.required, rules.emptyArray]" chips multiple>
+                <template v-if="props.recordId" v-slot:chip="{ item }">
+                  <v-chip
+                    small
+                    v-bind="attrs"
+                    :input-value="selected"
+                    close
+                    @click="subtaskClicked(item.raw)"
+                    @click:close="remove(item)"
+                  >
+                    {{ item.raw.name }}
+                  </v-chip>
+                </template>
+              
+              </v-combobox>
+              
             </v-col>
 
             <v-col cols="12" sm="12" md="12">
@@ -87,6 +116,7 @@ const submitInfo = ref('')
 const loading = ref(true)
 const confirmArchiveOverlay = ref(false)
 const readonly = ref(false)
+const editSubtaskOverlay = ref(false)
 
 const props = defineProps({
     recordId: String,
@@ -103,6 +133,8 @@ const editedItem = ref([
     link: '',
   }
 ])
+
+const editedSubtask = ref()
 
 const emit = defineEmits(['close', 'closeAndReload'])
 
@@ -279,6 +311,29 @@ async function save() {
     submitInfo.value = err
     console.log(err)
   }
+}
+
+
+function subtaskClicked(subtask) {
+  // grab the incoming subtask array index
+  subtask.index = editedItem.value.subtasks.map( subtask => subtask.id ).indexOf(subtask.id)
+
+  // assign subtask object to reactive field (to be used by form)
+  editedSubtask.value = Object.assign({}, subtask)
+
+  // open a modal with a (text) field bound to editedSubtask.value.name property
+  editSubtaskOverlay.value = true
+}
+
+
+function updateSubtask(subtask) {
+  console.log(subtask)
+}
+
+
+function closeAndClearEditSubtaskModal() {
+  editedSubtask.value = Object.assign({}, '')
+  editSubtaskOverlay.value = false
 }
 
 

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -81,7 +81,7 @@
                 </template> -->
               </v-combobox>
 
-              <v-label>Existing Subtasks: </v-label>
+              <v-label>Subtasks: </v-label>
               <v-chip v-for="subtask in editedItem.subtasks" @click="subtaskClicked(subtask)">
                 {{ subtask.name }}
               </v-chip>
@@ -351,6 +351,8 @@ async function save() {
           if (projectPutRes.status === 200 && subtasksPostRes.status === 200) {
             if (projectPutRes.data.response_code === 200 && subtasksPostRes.data.response_code === 200) {
               submitStatus.value = 'updated'
+              editedItem.value.subtasks.push(subtasksPostRes.data.data)
+              delete editedItem.value.newSubtasks
             } else {
               submitStatus.value = 'internal_api_error'
               submitInfo.value = data

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -269,7 +269,7 @@ async function save() {
   let data = Object.assign({}, editedItem.value)  // create a data object that will be passed to API to prevent user from seeing conversions
 
   try { 
-    const projectPostRes = await axios({
+    const projectRequestResponse = await axios({
       method: (!props.recordId) ? 'POST' : 'PUT',
       url: (!props.recordId) ? `${runtimeConfig.public.API_URL}/project/` : `${runtimeConfig.public.API_URL}/project/` + data.id,
       data: (!props.recordId) ? { 'name': data.name, 'link': data.link, 'billing_code': data.billing_code } 
@@ -279,8 +279,7 @@ async function save() {
       }
     })
     
-    // projectId = projectPostRes.data.data.id
-    projectId = (!props.recordId) ? projectPostRes.data.data.id : data.id
+    projectId = (!props.recordId) ? projectRequestResponse.data.data.id : data.id
 
     if(data.subtasks || data.newSubtasks) {
       if (props.recordId) {
@@ -289,7 +288,7 @@ async function save() {
       
       if(data.subtasks) {
         data.subtasks.forEach(async (subtask) => {
-          const subtasksPostRes = await axios({
+          const subtasksRequestResponse = await axios({
             method: 'POST',
             url: `${runtimeConfig.public.API_URL}/project/` + projectId + `/subtask`,
             data: { 'name': subtask },
@@ -298,37 +297,37 @@ async function save() {
             }
           })
 
-          if (projectPostRes.status === 200 && subtasksPostRes.status === 200) {
-            if (projectPostRes.data.response_code === 200 && subtasksPostRes.data.response_code === 200) {
+          if (projectRequestResponse.status === 200 && subtasksRequestResponse.status === 200) {
+            if (projectRequestResponse.data.response_code === 200 && subtasksRequestResponse.data.response_code === 200) {
               submitStatus.value = (!props.recordId) ? 'success' : 'updated'
               submitInfo.value = (!props.recordId) ? 'Project URL: ' + window.location.origin + '/projects?id=' + projectId : ''
               if(props.recordId) {
-                editedItem.value.subtasks.push(subtasksPostRes.data.data)
+                editedItem.value.subtasks.push(subtasksRequestResponse.data.data)
                 delete editedItem.value.newSubtasks
               }
 
             } else {
               submitStatus.value = 'internal_api_error'
               submitInfo.value = data
-              if (projectPostRes.data.response_code !== 200) {
-                console.log(projectPostRes)
+              if (projectRequestResponse.data.response_code !== 200) {
+                console.log(projectRequestResponse)
               }
-              if (subtasksPostRes.data.response_code !== 200) {
-                console.log(subtasksPostRes)
+              if (subtasksRequestResponse.data.response_code !== 200) {
+                console.log(subtasksRequestResponse)
               }
               return
             }
           }
         })
       } else {
-        if (projectPostRes.status === 200) {
-          if (projectPostRes.data.response_code === 200) {
+        if (projectRequestResponse.status === 200) {
+          if (projectRequestResponse.data.response_code === 200) {
             submitStatus.value = 'updated'
           } else {
             submitStatus.value = 'internal_api_error'
             submitInfo.value = data
-            if (projectPostRes.data.response_code !== 200) {
-              console.log(projectPostRes)
+            if (projectRequestResponse.data.response_code !== 200) {
+              console.log(projectRequestResponse)
             }
             return
           }

--- a/components/FormComponentProject.vue
+++ b/components/FormComponentProject.vue
@@ -64,7 +64,7 @@
               </v-combobox>
 
               <v-label>Subtasks: </v-label>
-              <v-chip v-for="subtask in editedItem.subtasks" @click="openEditSubtaskModal(subtask)">
+              <v-chip v-for="subtask in editedItem.subtasks" @click="openEditSubtaskModal(subtask)" :disabled="readonly">
                 {{ subtask.name }}
               </v-chip>
             </v-col>

--- a/components/ModalComp.vue
+++ b/components/ModalComp.vue
@@ -32,8 +32,11 @@
                         <v-card-text>
                             <v-form ref="form" @submit.prevent="submit">
                                 <v-row>
-                                    <v-col v-for="field in fields" cols="12" sm="12" md="12">
+                                    <v-col v-if="fields.length > 0" v-for="field in fields" cols="12" sm="12" md="12">
                                         <v-text-field v-model="field.value" :label="field.name"></v-text-field>
+                                    </v-col>
+                                    <v-col v-else>
+                                        <v-label>{{ cardText }}</v-label>
                                     </v-col>
                                 </v-row>
                             </v-form>
@@ -41,8 +44,8 @@
                         <v-card-actions>
                             <v-row>
                                 <v-col class="text-right">
-                                    <v-btn variant="plain" @click="emit('close')" :title=props.cancelBtnText>{{ props.cancelBtnText }}</v-btn>
-                                    <v-btn class="rounded" color="error" :title=props.confirmBtnText @click="emit('confirm', fields)">{{ props.confirmBtnText }}</v-btn>
+                                    <v-btn variant="plain" @click="emit('close')" :title=props.cancelBtnText>{{ (fields.length > 0) ? props.cancelBtnText : 'Close' }}</v-btn>
+                                    <v-btn v-if="fields.length > 0" :disabled="showConfirmBtn" class="rounded" color="error" :title=props.confirmBtnText @click="emit('confirm', fields)">{{ props.confirmBtnText }}</v-btn>
                                 </v-col>
                             </v-row>
                         </v-card-actions>

--- a/components/ModalComp.vue
+++ b/components/ModalComp.vue
@@ -25,6 +25,28 @@
                             {{ props.confirmBtnText }}
                         </v-btn>
                     </v-card>
+
+                    <v-card v-if="props.type === 'form'" style="font-family:'Open Sans'; min-width: 500px;">
+                        <v-card-title>{{ props.cardTitle }}</v-card-title>
+                        <v-spacer></v-spacer>
+                        <v-card-text>
+                            <v-form ref="form" @submit.prevent="submit">
+                                <v-row>
+                                    <v-col cols="12" sm="12" md="12">
+                                        <v-text-field v-model="fields.name" label="Subtask"></v-text-field>
+                                    </v-col>
+                                </v-row>
+                            </v-form>
+                        </v-card-text>
+                        <v-card-actions>
+                            <v-row>
+                                <v-col class="text-right">
+                                    <v-btn variant="plain" @click="emit('close')" :title=props.cancelBtnText>{{ props.cancelBtnText }}</v-btn>
+                                    <v-btn class="rounded" color="error" :title=props.confirmBtnText @click="emit('confirm', fields)">{{ props.confirmBtnText }}</v-btn>
+                                </v-col>
+                            </v-row>
+                        </v-card-actions>
+                    </v-card>
                 </v-col>
             </v-row>
         </v-container>
@@ -39,7 +61,10 @@ const props = defineProps({
     cancelBtnText: String,
     confirmBtnText: String,
     submitStatus: String,
+    fields: Object,
 })
+
+const { fields } = toRefs(props);
 
 const emit = defineEmits(['close', 'confirm'])
 </script>

--- a/components/ModalComp.vue
+++ b/components/ModalComp.vue
@@ -32,8 +32,8 @@
                         <v-card-text>
                             <v-form ref="form" @submit.prevent="submit">
                                 <v-row>
-                                    <v-col cols="12" sm="12" md="12">
-                                        <v-text-field v-model="fields.name" label="Subtask"></v-text-field>
+                                    <v-col v-for="field in fields" cols="12" sm="12" md="12">
+                                        <v-text-field v-model="field.value" :label="field.name"></v-text-field>
                                     </v-col>
                                 </v-row>
                             </v-form>

--- a/components/ModalComp.vue
+++ b/components/ModalComp.vue
@@ -32,12 +32,15 @@
                         <v-card-text>
                             <v-form ref="form" @submit.prevent="submit">
                                 <v-row>
-                                    <v-col v-if="fields.length > 0" v-for="field in fields" cols="12" sm="12" md="12">
+                                    <v-col v-for="field in fields" cols="12" sm="12" md="12">
+                                        <v-text-field v-model="field.value" :label="field.name"></v-text-field>
+                                    </v-col>
+                                    <!-- <v-col v-if="fields.length > 0" v-for="field in fields" cols="12" sm="12" md="12">
                                         <v-text-field v-model="field.value" :label="field.name"></v-text-field>
                                     </v-col>
                                     <v-col v-else>
                                         <v-label>{{ cardText }}</v-label>
-                                    </v-col>
+                                    </v-col> -->
                                 </v-row>
                             </v-form>
                         </v-card-text>

--- a/components/ModalComp.vue
+++ b/components/ModalComp.vue
@@ -35,12 +35,6 @@
                                     <v-col v-for="field in fields" cols="12" sm="12" md="12">
                                         <v-text-field v-model="field.value" :label="field.name"></v-text-field>
                                     </v-col>
-                                    <!-- <v-col v-if="fields.length > 0" v-for="field in fields" cols="12" sm="12" md="12">
-                                        <v-text-field v-model="field.value" :label="field.name"></v-text-field>
-                                    </v-col>
-                                    <v-col v-else>
-                                        <v-label>{{ cardText }}</v-label>
-                                    </v-col> -->
                                 </v-row>
                             </v-form>
                         </v-card-text>


### PR DESCRIPTION
This PR introduces the following: 
- Gives Admin user the ability to update Project and Subtask information as needed.
- In a Project record, if there are existing Subtasks associated to it, users will be able edit those on a separate field vla pill click.
- To add more subtasks, users can click on the "Add more subtasks" button, which will display a combobox to add more fields.
- This was done this way due to the fact that newly added subtasks won't have IDs associated to them until the project record is saved.