### PR TITLE
Add project billing code to form and fix bug where wrong filter is highlighted

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -178,7 +178,6 @@ const editedItem = ref([
     creator: '',
     description: '',
     due_date: '',
-    project: '',
     id: '',
     links: '',
     subtask: '',
@@ -329,6 +328,10 @@ async function loadItem() {
           editedItem.value.links = linksArray
         }
 
+        if (editedItem.value.project.isarchived === '1') {
+          editedItem.value.project.name = editedItem.value.project.name + ' (' + editedItem.value.project.billing_code + ')'
+        }
+
         loadProjects()
         loadSubtasks(editedItem.value.project.id)
     } catch (err) {
@@ -388,7 +391,7 @@ function loadProjects() {
     projects.value = filteredResponse.map((item) => {
       return {
         id: item.id,
-        name: item.name
+        name: item.name + ' (' + item.billing_code + ')'
       }
     })
   })

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -48,7 +48,7 @@
           </template>
 
           <template v-slot:item.project="{ item }">
-            {{ item.raw.project.name + ' | ' + item.raw.subtask.name  }}
+            {{ item.raw.project.name + ' (' + item.raw.project.billing_code + ') | ' + item.raw.subtask.name  }}
           </template>
 
           <template v-slot:item.creator="{ item }">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -160,9 +160,10 @@
     recordPageCheck()
   )
 
+  // used to set the active filter when user redirects back to table page
   watch(() => route.query, () => {
     setTimeout(() => {
-      (!isRecordPage.value) ? filteringMethod(activeFilter.value) : '' 
+      if(!isRecordPage.value) filteringMethod(activeFilter.value)
     }, "100")
   })
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -123,6 +123,7 @@
   const userInfoStore = useUserInfoStore()
   const route = useRoute()
   const drawer = ref(true)
+  const activeFilter = ref('')
 
   const displayLoadingMessage = ref(false)
   provide('displayLoadingMessage', displayLoadingMessage)
@@ -159,6 +160,12 @@
     recordPageCheck()
   )
 
+  watch(() => route.query, () => {
+    setTimeout(() => {
+      (!isRecordPage.value) ? filteringMethod(activeFilter.value) : '' 
+    }, "100")
+  })
+
 
   async function signInAction() {
     await signIn()
@@ -184,6 +191,8 @@
   // increment counter to guarantee new value in component watcher 
   // TODO: figure out a better to toggle CSS classes. just make it work for now.
   function filteringMethod(filter_name) {
+    activeFilter.value = filter_name
+
     if (filter_name === 'filterByUser') {
       filterByUserTrigger.value++
 


### PR DESCRIPTION
This PR does the following:
- Displays project billing codes within the "project" drop down.
- Fixes a bug where if a user has a filter selected in the nav bar, then goes to a record page or a different route, it will highlight the previously selected filter when they navigate back to the page.