### PR TITLE
UAT changes (8/11/2023)

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -364,7 +364,7 @@ function loadTags() {
   .then((response) => {
     tags.value = response.data.data.map((item) => {
       return {
-        title: item.name,
+        title: item.name.toUpperCase(),
         value: item.id
       }
     })

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -408,6 +408,10 @@ function loadProjects() {
         link: item.link
       }
     })
+
+    // sort projects list
+    projects.value = projects.value.sort((a, b) => 
+      a.name.localeCompare(b.name))
   })
   .catch(err => console.log(err))
 }
@@ -422,6 +426,10 @@ function loadSubtasks(projectId) {
         name: item.name
       }
     })
+
+    // sort subtasks list
+    subtasks.value = subtasks.value.sort((a, b) => 
+      a.name.localeCompare(b.name))
   })
   .catch(err => console.log(err))
 }

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -60,7 +60,7 @@
           </template>
 
           <template v-slot:item.tags="{ item }">
-            <v-chip v-for="tag in item.raw.tags">{{ tag.name }}</v-chip>
+            <v-chip v-for="tag in item.raw.tags">{{ tag.name.toUpperCase() }}</v-chip>
           </template>
 
           <template v-slot:item.status="{ item }">

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -6,7 +6,7 @@
       </v-card>
       <v-card v-else width="100vw">
         <div class="d-flex mb-2">
-          <v-select v-model="selectedAssignee" hide-details=true label="Filter by Assignee" :items="props.persons" class="pr-10"></v-select>
+          <v-autocomplete v-model="selectedAssignee" hide-details=true label="Filter by Assignee" :items="props.persons" class="pr-10"></v-autocomplete>
           <v-text-field
             v-model="searchString"
             prepend-icon="mdi-magnify"


### PR DESCRIPTION
This PR does the following:
- Capitalizes names of Type options
- Sort Projects and Subtasks in alphabetical order
- Changes the "Filter by Assignee" drop-down to use <v-autocomplete> component