### PR TITLE
Change Share Button Text Logic and Styling

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -112,7 +112,8 @@
           <v-card-actions>
             <v-row>
               <v-col v-if="props.recordId" class="text-left">
-                <v-btn variant="plain" class="rounded" @click="copyLink" title="Copy record link">{{ copyUrlBtnText }}</v-btn>
+                <v-btn variant="plain" class="rounded" append-icon="mdi-share" @click="copyLink" title="Share record link">Share</v-btn><br/>
+                <v-label v-if="showUrlCopyConfirmMsg" class="pr-2 pl-2">Record link copied</v-label>
               </v-col>
               <v-col class="text-right">
                 <v-btn variant="plain" class="rounded" @click="close" :title="`${ cancelBtnText }`">{{ cancelBtnText }}</v-btn>
@@ -161,7 +162,7 @@ const submitBtnDisabled = ref(false)
 const submitStatusOverlay = ref(false)
 const submitStatus = ref('')
 const submitInfo = ref('')
-const urlCopied = ref(false)
+const showUrlCopyConfirmMsg = ref(false)
 const displayShareBtn = ref(false)
 const shareUrl = ref('')
 const linkTemp = ref('')
@@ -218,11 +219,6 @@ const submitBtnText = computed(() => {
 const cancelBtnText = computed(() => {
   return (!props.recordId) ? 'Cancel' : 
     (readonly.value) ? 'Close' : 'Cancel'
-})
-
-// computed value for copy record link button text
-const copyUrlBtnText = computed(() => {
-  return (urlCopied.value) ? 'Record Link Copied' : 'Copy Record Link'
 })
 
 // computed value for work order submit progress messages
@@ -586,7 +582,12 @@ function close() {
 function copyLink() {
   const url = (!props.recordId) ? shareUrl.value : window.location.href
   window.navigator.clipboard.writeText(url)
-  urlCopied.value = true
+  showUrlCopyConfirmMsg.value = true
+
+  // hide message after 3 seconds
+  setTimeout(() => {
+    showUrlCopyConfirmMsg.value = false
+  }, 3000)
 }
 
 

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -112,8 +112,8 @@
           <v-card-actions>
             <v-row>
               <v-col v-if="props.recordId" class="text-left">
-                <v-btn variant="plain" class="rounded" append-icon="mdi-share" @click="copyLink" title="Share record link">Share</v-btn><br/>
-                <v-fade-transition><v-label v-if="showUrlCopyConfirmMsg" class="pr-2 pl-2">Record link copied</v-label></v-fade-transition>
+                <v-btn variant="tonal" class="rounded" color="#428086" size="small" append-icon="mdi-share" @click="copyLink" title="Share record link">Share</v-btn><br/>
+                <v-fade-transition><v-label v-if="showUrlCopyConfirmMsg" style="font-size:13px">Record link copied</v-label></v-fade-transition>
               </v-col>
               <v-col class="text-right">
                 <v-btn variant="plain" class="rounded" @click="close" :title="`${ cancelBtnText }`">{{ cancelBtnText }}</v-btn>

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -113,7 +113,7 @@
             <v-row>
               <v-col v-if="props.recordId" class="text-left">
                 <v-btn variant="plain" class="rounded" append-icon="mdi-share" @click="copyLink" title="Share record link">Share</v-btn><br/>
-                <v-label v-if="showUrlCopyConfirmMsg" class="pr-2 pl-2">Record link copied</v-label>
+                <v-fade-transition><v-label v-if="showUrlCopyConfirmMsg" class="pr-2 pl-2">Record link copied</v-label></v-fade-transition>
               </v-col>
               <v-col class="text-right">
                 <v-btn variant="plain" class="rounded" @click="close" :title="`${ cancelBtnText }`">{{ cancelBtnText }}</v-btn>


### PR DESCRIPTION
This PR does the following:
- Converts copy URL button label from a computed prop to a static string labeled "Share" with an appended mdi-share icon.
- Styles button to be more visible and downsizes it.
- Displays a message for 3 seconds below the button after it is clicked letting the user know that they've copied the record URL.