### PR TITLE
Add table sorting, preset Priority default to "Normal" when creating a new WO

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -443,6 +443,11 @@ function loadPriorities() {
         description: item.description,
       }
     })
+
+    // set priority to "normal" when creating a new work order. 
+    if(!props.recordId) {
+      editedItem.value.priority = '3'
+    }
   })
   .catch(err => console.log(err))
 }

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -52,7 +52,7 @@
                 </v-col>
 
                 <v-col cols="12" sm="12" md="12">
-                  <v-select v-model="editedItem.tags" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]" multiple chips clearable></v-select>
+                  <v-select v-model="editedItem.tags" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]" chips></v-select>
                 </v-col>
 
                 <v-col v-if="props.recordId" cols="12" sm="6" md="6">

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -59,8 +59,8 @@
             <v-chip v-for="assignee in item.raw.assignees">{{ assignee.name }}</v-chip>
           </template>
 
-          <template v-slot:item.tags="{ item }">
-            <v-chip v-for="tag in item.raw.tags">{{ tag.name.toUpperCase() }}</v-chip>
+          <template v-slot:item.tag="{ item }">
+            <v-chip v-for="tag in item.raw.tag">{{ tag.name.toUpperCase() }}</v-chip>
           </template>
 
           <template v-slot:item.status="{ item }">
@@ -139,7 +139,7 @@ const headers = [
   { title: 'Project', key: 'project', align: 'start', sortable: false },
   { title: 'Created By', key: 'creator', align: 'start', sortable: false },
   { title: 'Assignee(s)', key: 'assignees', align: 'start', sortable: false },
-  { title: 'Type', key: 'tags', align: 'start', sortable: true },
+  { title: 'Type', key: 'tag', align: 'start', sortable: true },
   { title: 'Status', key: 'status', align: 'center', sortable: true },
   { title: 'Priority', key: 'priority', align: 'center', sortable: true },
   { title: 'Due Date', key: 'due_date', align: 'center', sortable: true },
@@ -307,7 +307,7 @@ function loadItems({ sortBy }) {
         project: item.project,
         status: item.status,
         subtask: item.subtask,
-        tags: item.tags,
+        tag: item.tags,
         time_estimate: item.time_estimate,
         watchers: item.watchers
       }

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -199,7 +199,7 @@ watch(showNonCompletedTrigger, (currentValue, newValue) => {
       if(selectedAssignee.value != '0') {
         selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
       } else {
-        loadItems()
+        loadItems({ sortBy: [] })
       }
     }
   }
@@ -214,7 +214,7 @@ watch(showCompletedTrigger, (currentValue, newValue) => {
       if(selectedAssignee.value != '0') {
         selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
       } else {
-        loadItems()
+        loadItems({ sortBy: [] })
       }
     }
   }
@@ -223,7 +223,7 @@ watch(showCompletedTrigger, (currentValue, newValue) => {
 // reload table when selectedAssignee data is changed
 watch(selectedAssignee, (currentValue, newValue) => {
   if(currentValue !== newValue) {
-    loadItems()
+    loadItems({ sortBy: [] })
   }
 })
 
@@ -330,7 +330,7 @@ function close() {
 
 function closeAndReload() {
   dialog.value = false
-  loadItems()
+  loadItems({ sortBy: [] })
 }
 
 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -139,10 +139,10 @@ const headers = [
   { title: 'Project', key: 'project', align: 'start', sortable: false },
   { title: 'Created By', key: 'creator', align: 'start', sortable: false },
   { title: 'Assignee(s)', key: 'assignees', align: 'start', sortable: false },
-  { title: 'Type', key: 'tags', align: 'start', sortable: false },
-  { title: 'Status', key: 'status', align: 'center', sortable: false },
-  { title: 'Priority', key: 'priority', align: 'center', sortable: false },
-  { title: 'Due Date', key: 'due_date', align: 'center', sortable: false },
+  { title: 'Type', key: 'tags', align: 'start', sortable: true },
+  { title: 'Status', key: 'status', align: 'center', sortable: true },
+  { title: 'Priority', key: 'priority', align: 'center', sortable: true },
+  { title: 'Due Date', key: 'due_date', align: 'center', sortable: true },
   { title: 'Actions', key: 'actions', align: 'center', sortable: false },
 ]
 
@@ -256,7 +256,7 @@ function setMenuItems() {
 }
 
 
-function loadItems() {
+function loadItems({ sortBy }) {
   loading.value = true
 
   let axiosGetRequestURL = `${runtimeConfig.public.API_URL}/workorders?page=` + page.value + `&page_size=` + itemsPerPage.value
@@ -282,6 +282,14 @@ function loadItems() {
     )
 
     axiosGetRequestURL = axiosGetRequestURL + statusQueryStr
+  }
+
+  // set sorting params here
+  if(sortBy[0]) {
+    let sortingQueryStr = ''
+    sortingQueryStr = (sortBy[0].order === 'desc') ? `&orderby=` + sortBy[0].key + `&reverse=true` : `&orderby=` + sortBy[0].key
+
+    axiosGetRequestURL = axiosGetRequestURL + sortingQueryStr
   }
 
   axios.get(axiosGetRequestURL)

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -287,7 +287,7 @@ function loadItems({ sortBy }) {
   // set sorting params here
   if(sortBy[0]) {
     let sortingQueryStr = ''
-    sortingQueryStr = (sortBy[0].order === 'desc') ? `&orderby=` + sortBy[0].key + `&reverse=true` : `&orderby=` + sortBy[0].key
+    sortingQueryStr = (sortBy[0].order === 'desc') ? `&order_by=` + sortBy[0].key + `&reverse=true` : `&order_by=` + sortBy[0].key
 
     axiosGetRequestURL = axiosGetRequestURL + sortingQueryStr
   }


### PR DESCRIPTION
This PR does the following:
- Gives users the ability to sort Work Orders by Type, Status, Priority, and Due Date fields.
- When creating a new Work Order, preset the Priority field to "Normal". User can still change this on WO creation if they need to.