### PR TITLE
Single Tag/Type for WOs, fix Assignee filter

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -52,7 +52,7 @@
                 </v-col>
 
                 <v-col cols="12" sm="12" md="12">
-                  <v-select v-model="editedItem.tag" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]" chips></v-select>
+                  <v-select v-model="editedItem.tag" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]"></v-select>
                 </v-col>
 
                 <v-col v-if="props.recordId" cols="12" sm="6" md="6">
@@ -485,10 +485,6 @@ function save() {
       data.watchers = 0
     }
 
-    if (data.tags && data.tags.length === 0) {
-      data.tags = 0
-    }
-
     // PUT endpoint requires 'subtaskid', whereas POST requires 'subtask'
     data.subtaskid = data.subtask
     delete data.subtask
@@ -504,6 +500,15 @@ function save() {
       data.priorityid = data.priority.id
     } else {
       data.priorityid = data.priority
+    }
+  }
+
+  // hack warning: since API only accepts "tagid" to set tag/type, but fetched data contains a "tag" object.
+  if(data.tag) {
+    if(data.tag.id) {
+      data.tagid = data.tag.id
+    } else {
+      data.tagid = data.tag
     }
   }
 

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -52,7 +52,7 @@
                 </v-col>
 
                 <v-col cols="12" sm="12" md="12">
-                  <v-select v-model="editedItem.tags" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]" chips></v-select>
+                  <v-select v-model="editedItem.tag" label="Type" :items="tags" item-title="title" item-value="value" :rules="[rules.select]" chips></v-select>
                 </v-col>
 
                 <v-col v-if="props.recordId" cols="12" sm="6" md="6">
@@ -186,7 +186,7 @@ const editedItem = ref([
     priority: '',
     project: '',
     status: '',
-    tags: '',
+    tag: '',
     time_estimate: '',
     watchers: ''
   },
@@ -305,14 +305,6 @@ async function loadItem() {
         editedItem.value = Object.assign({}, response.data.data[0])
 
         // for arrays
-        if(editedItem.value.tags) {
-          let tagsTemp = []
-          editedItem.value.tags.forEach((tag) => {
-            tagsTemp.push(tag.id)
-          })
-          editedItem.value.tags = tagsTemp
-        }
-
         if(editedItem.value.assignees) {
           let assigneesTemp = []
           editedItem.value.assignees.forEach((assignee) => {
@@ -331,6 +323,7 @@ async function loadItem() {
 
         // for objects
         editedItem.value.status = editedItem.value.status.id
+        editedItem.value.tag = editedItem.value.tag.id
 
         // make an array of links. used to make individual clickable v-chips
         // delimiter is a comma - update later if this isn't acceptable

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -60,7 +60,7 @@
           </template>
 
           <template v-slot:item.tag="{ item }">
-            <v-chip v-for="tag in item.raw.tag">{{ tag.name.toUpperCase() }}</v-chip>
+            <v-chip>{{ item.raw.tag.name.toUpperCase() }}</v-chip>
           </template>
 
           <template v-slot:item.status="{ item }">
@@ -307,7 +307,7 @@ function loadItems({ sortBy }) {
         project: item.project,
         status: item.status,
         subtask: item.subtask,
-        tag: item.tags,
+        tag: item.tag,
         time_estimate: item.time_estimate,
         watchers: item.watchers
       }

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -264,7 +264,7 @@ function loadItems({ sortBy }) {
   if(search.value) axiosGetRequestURL = axiosGetRequestURL + `&search=` + search.value
 
   // filter by user if a valid user is selected
-  if(selectedAssignee.value !== '0') axiosGetRequestURL = axiosGetRequestURL + `&assignees[]=` + selectedAssignee.value
+  if(selectedAssignee.value !== '0') axiosGetRequestURL = axiosGetRequestURL + `&assignee=` + selectedAssignee.value
 
   // set display completed work order filter
   if(showCompleted.value) {


### PR DESCRIPTION
This PR will do the following:
- Follows backend model and naming convention for Tag/Type - one Tag/Type per Work Order.
- Fix GET request to search by only "assignee" as opposed to an array of "assignees".